### PR TITLE
chore: 搭建 Cursor Cloud 开发环境并补充 AGENTS 说明

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -172,3 +172,11 @@ Test Agent 原则：
 - 跨 Agent：`docs/unified-run-contract.md`、`docs/cross-agent-acceptance.md`、`docs/platform-capability-inventory.md`。
 - 自然语言测试：`docs/natural-language-testing/`；规格文件：`docs/process/specs/`。
 - Beta Epics/Story：`_bmad-output/planning-artifacts/beta-epics.md`；Sprint 状态：`_bmad-output/implementation-artifacts/sprint-status.yaml`。
+
+## Cursor Cloud specific instructions
+
+- 运行环境是 **Linux 云 VM**，而本框架目标平台是 Windows 11 / macOS。真实游戏《杀戮尖塔 2》（经由 Steam）在此无法运行，因此所有 `@pytest.mark.requires_game` 测试、`autotest doctor` / `serve` 的 readiness 检查、以及任何驱动游戏的流程都属于 **BLOCKED**（缺环境，而非 bug）。可离线验证的核心功能：单元测试、`mypy`、`lint-imports`，以及 NL 规格流水线 `autotest review` / `autotest compile`（把 `docs/process/specs/` 的 Markdown 编译成 pytest 文件）。
+- 依赖安装在仓库根的 **`.venv/`**（已 gitignore，由 update script 用 `pip install -e ".[dev,visual]"` 建立，含可选 `[visual]`=opencv 以让 `mypy --strict` 干净通过）。用 `source .venv/bin/activate` 或直接 `.venv/bin/<工具>`（如 `.venv/bin/pytest`、`.venv/bin/mypy`、`.venv/bin/autotest`）运行；命令本身见 README / 上文「构建与开发命令」，无需重复。
+- 创建 venv 需要系统包 `python3.12-venv`（`apt install python3.12-venv`），已装入快照；update script 只做 venv + pip，不装系统依赖。
+- 本 Linux VM 的单元测试基线：**1685 passed, 8 failed**。这 8 个失败均为平台/环境专属，非回归：`tests/unit/test_mcp_tools.py` 里 4 个用例硬编码 macOS 家目录路径（`/Users/chris/STS2-WORKSPACE/...`，在 Linux 上超出 `~/STS2-WORKSPACE` 白名单）；`tests/unit/test_smoke_card_validation.py` 里 4 个需要 macOS/Windows 的 Steam/Godot 可执行文件。
+- `ruff check src/ tests/` 在默认规则下有大量既存 style 报错（仓库无 ruff 配置），非本环境引入；改代码时以不新增为准。


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 概述

为本仓库在 Cursor Cloud（Linux VM）上搭建开发环境，并验证核心功能可运行。仅新增 `AGENTS.md` 的 `## Cursor Cloud specific instructions` 段落，未改动任何源码。

## 环境搭建

- 安装系统包 `python3.12-venv`（快照持久化），在仓库根创建 `.venv/`（已 gitignore）。
- `pip install -e ".[dev,visual]"` 安装框架 + dev + 可选 `[visual]`（opencv，用于 `mypy --strict` 干净通过）。
- Update script（VM 启动时自动运行）：`python3 -m venv .venv` → 升级 pip → `pip install -e ".[dev,visual]"`。

## 验证证据

| 检查 | 命令 | 结果 |
|------|------|------|
| 导入契约 | `lint-imports` | Contracts: 1 kept, 0 broken |
| 类型 | `mypy src/sts2_autotest --strict` | Success: no issues found in 70 source files |
| 单元测试 | `pytest tests/unit/ -q` | 1685 passed, 8 failed（8 个为 macOS/Windows 专属，见下） |
| 应用（NL 流水线） | `autotest review` + `autotest compile` | 3 规格审查全 PASS，生成 3 个 pytest 文件 |
| 服务 | `autotest serve` → `GET /health/live` | HTTP 200 `{"status":"ok"}` |

### 8 个失败说明（平台专属，非回归）

- `tests/unit/test_mcp_tools.py`（4 个）：硬编码 macOS 家目录 `/Users/chris/STS2-WORKSPACE/...`，在 Linux 超出 `~/STS2-WORKSPACE` 白名单。
- `tests/unit/test_smoke_card_validation.py`（4 个）：需要 macOS/Windows 的 Steam/Godot 可执行文件。

真实游戏经由 Steam 无法在 Linux 云 VM 运行，故 `@pytest.mark.requires_game` 与 `doctor`/`serve` 的 readiness 属 BLOCKED（缺环境，非 bug）。

## 验证日志

[autotest verification log](https://cursor.com/agents/bc-42c36b1c-deb6-4562-8615-3b837567d4b2/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fautotest_verification.txt)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-42c36b1c-deb6-4562-8615-3b837567d4b2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-42c36b1c-deb6-4562-8615-3b837567d4b2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

