### PR TITLE
quality: 第一批 Ruff 历史债 473→357

### DIFF
--- a/.github/scripts/check_ruff_baseline.py
+++ b/.github/scripts/check_ruff_baseline.py
@@ -81,6 +81,17 @@ def _fingerprints(
     return counts, details
 
 
+def _rule_counts(findings: list[dict[str, Any]]) -> Counter[str]:
+    return Counter(str(finding.get("code") or "unknown") for finding in findings)
+
+
+def _print_rule_counts(label: str, findings: list[dict[str, Any]]) -> None:
+    counts = _rule_counts(findings)
+    print(f"{label} Ruff findings by rule:")
+    for code, count in counts.most_common():
+        print(f"  {code}: {count}")
+
+
 def _print_new_findings(
     new_findings: Counter[IssueKey],
     details: dict[IssueKey, dict[str, Any]],
@@ -107,8 +118,10 @@ def main() -> int:
     baseline_dir = args.baseline_dir.resolve()
     current_dir = args.current_dir.resolve()
 
-    baseline_counts, _ = _fingerprints(baseline_dir, _run_ruff(baseline_dir))
-    current_counts, current_details = _fingerprints(current_dir, _run_ruff(current_dir))
+    baseline_findings = _run_ruff(baseline_dir)
+    current_findings = _run_ruff(current_dir)
+    baseline_counts, _ = _fingerprints(baseline_dir, baseline_findings)
+    current_counts, current_details = _fingerprints(current_dir, current_findings)
 
     new_findings = current_counts - baseline_counts
     resolved_findings = baseline_counts - current_counts
@@ -117,6 +130,7 @@ def main() -> int:
     print(f"Current PR: {sum(current_counts.values())} finding(s)")
     print(f"Resolved by this PR: {sum(resolved_findings.values())}")
     print(f"New in this PR: {sum(new_findings.values())}")
+    _print_rule_counts("Current", current_findings)
 
     if new_findings:
         _print_new_findings(new_findings, current_details)

--- a/.github/scripts/check_ruff_baseline.py
+++ b/.github/scripts/check_ruff_baseline.py
@@ -1,5 +1,9 @@
 #!/usr/bin/env python3
-"""Fail CI only when a pull request introduces new Ruff findings."""
+"""Fail CI only when a pull request introduces new Ruff findings.
+
+During Ruff debt cleanup, also print the current finding count by rule so each
+batch can be selected by risk instead of applying every available auto-fix.
+"""
 
 from __future__ import annotations
 

--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -13,7 +13,37 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  # ── 并行阶段 1：代码质量检查 ──
+  ruff-debt-autofix:
+    name: Ruff Debt Autofix (batch 1)
+    if: github.event.pull_request.head.repo.full_name == github.repository && github.head_ref == 'quality/ruff-debt-batch-1'
+    permissions:
+      contents: write
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.ref }}
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - name: Install Ruff
+        run: pip install 'ruff==0.16.2'
+      - name: Apply selected low-risk fixes
+        run: ruff check src tests --fix --select I001,RUF022,F541 --exit-zero
+      - name: Commit fixes when needed
+        shell: bash
+        run: |
+          if git diff --quiet; then
+            echo "No selected Ruff fixes remain."
+            exit 0
+          fi
+          git diff --check
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add src tests
+          git commit -m "quality: remove safe Ruff debt batch"
+          git push origin HEAD:${{ github.event.pull_request.head.ref }}
 
   lint:
     name: Lint (ruff)
@@ -79,8 +109,6 @@ jobs:
       - name: Run lint-imports
         run: lint-imports
 
-  # ── 阶段 2：单元测试（等待阶段 1 全部通过）──
-
   unit-test:
     name: Unit Tests
     needs: [lint, mypy, lint-imports]
@@ -105,8 +133,6 @@ jobs:
         with:
           name: junit-unit-${{ matrix.os }}
           path: junit-unit.xml
-
-  # ── 阶段 3：真实 CLI 集成测试（需要自托管 Mac）──
 
   cli-integration:
     name: CLI Integration Tests
@@ -140,8 +166,6 @@ jobs:
         with:
           name: junit-integration
           path: junit-integration.xml
-
-  # ── Job Summary ──
 
   summary:
     name: PR Check Summary

--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -13,7 +13,37 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  # ── 并行阶段 1：代码质量检查 ──
+  ruff-debt-autofix:
+    name: Ruff Debt Autofix (lifecycle UP035)
+    if: github.event.pull_request.head.repo.full_name == github.repository && github.head_ref == 'quality/ruff-debt-batch-1'
+    permissions:
+      contents: write
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.ref }}
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - name: Install Ruff
+        run: pip install 'ruff==0.16.2'
+      - name: Fix lifecycle Callable import
+        run: ruff check src/sts2_autotest/core/lifecycle.py --fix --select UP035,I001 --exit-zero
+      - name: Commit fix when needed
+        shell: bash
+        run: |
+          if git diff --quiet; then
+            echo "No lifecycle import fix needed."
+            exit 0
+          fi
+          git diff --check
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add src/sts2_autotest/core/lifecycle.py
+          git commit -m "quality: fix lifecycle Callable import"
+          git push origin HEAD:${{ github.event.pull_request.head.ref }}
 
   lint:
     name: Lint (ruff)
@@ -79,8 +109,6 @@ jobs:
       - name: Run lint-imports
         run: lint-imports
 
-  # ── 阶段 2：单元测试（等待阶段 1 全部通过）──
-
   unit-test:
     name: Unit Tests
     needs: [lint, mypy, lint-imports]
@@ -105,8 +133,6 @@ jobs:
         with:
           name: junit-unit-${{ matrix.os }}
           path: junit-unit.xml
-
-  # ── 阶段 3：真实 CLI 集成测试（需要自托管 Mac）──
 
   cli-integration:
     name: CLI Integration Tests
@@ -140,8 +166,6 @@ jobs:
         with:
           name: junit-integration
           path: junit-integration.xml
-
-  # ── Job Summary ──
 
   summary:
     name: PR Check Summary

--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -13,37 +13,7 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  ruff-debt-autofix:
-    name: Ruff Debt Autofix (batch 1)
-    if: github.event.pull_request.head.repo.full_name == github.repository && github.head_ref == 'quality/ruff-debt-batch-1'
-    permissions:
-      contents: write
-    runs-on: ubuntu-latest
-    timeout-minutes: 10
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          ref: ${{ github.event.pull_request.head.ref }}
-      - uses: actions/setup-python@v5
-        with:
-          python-version: '3.11'
-      - name: Install Ruff
-        run: pip install 'ruff==0.16.2'
-      - name: Apply selected low-risk fixes
-        run: ruff check src tests --fix --select I001,RUF022,F541 --exit-zero
-      - name: Commit fixes when needed
-        shell: bash
-        run: |
-          if git diff --quiet; then
-            echo "No selected Ruff fixes remain."
-            exit 0
-          fi
-          git diff --check
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git add src tests
-          git commit -m "quality: remove safe Ruff debt batch"
-          git push origin HEAD:${{ github.event.pull_request.head.ref }}
+  # ── 并行阶段 1：代码质量检查 ──
 
   lint:
     name: Lint (ruff)
@@ -109,6 +79,8 @@ jobs:
       - name: Run lint-imports
         run: lint-imports
 
+  # ── 阶段 2：单元测试（等待阶段 1 全部通过）──
+
   unit-test:
     name: Unit Tests
     needs: [lint, mypy, lint-imports]
@@ -133,6 +105,8 @@ jobs:
         with:
           name: junit-unit-${{ matrix.os }}
           path: junit-unit.xml
+
+  # ── 阶段 3：真实 CLI 集成测试（需要自托管 Mac）──
 
   cli-integration:
     name: CLI Integration Tests
@@ -166,6 +140,8 @@ jobs:
         with:
           name: junit-integration
           path: junit-integration.xml
+
+  # ── Job Summary ──
 
   summary:
     name: PR Check Summary

--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -13,37 +13,7 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  ruff-debt-autofix:
-    name: Ruff Debt Autofix (lifecycle UP035)
-    if: github.event.pull_request.head.repo.full_name == github.repository && github.head_ref == 'quality/ruff-debt-batch-1'
-    permissions:
-      contents: write
-    runs-on: ubuntu-latest
-    timeout-minutes: 10
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          ref: ${{ github.event.pull_request.head.ref }}
-      - uses: actions/setup-python@v5
-        with:
-          python-version: '3.11'
-      - name: Install Ruff
-        run: pip install 'ruff==0.16.2'
-      - name: Fix lifecycle Callable import
-        run: ruff check src/sts2_autotest/core/lifecycle.py --fix --select UP035,I001 --exit-zero
-      - name: Commit fix when needed
-        shell: bash
-        run: |
-          if git diff --quiet; then
-            echo "No lifecycle import fix needed."
-            exit 0
-          fi
-          git diff --check
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git add src/sts2_autotest/core/lifecycle.py
-          git commit -m "quality: fix lifecycle Callable import"
-          git push origin HEAD:${{ github.event.pull_request.head.ref }}
+  # ── 并行阶段 1：代码质量检查 ──
 
   lint:
     name: Lint (ruff)
@@ -109,6 +79,8 @@ jobs:
       - name: Run lint-imports
         run: lint-imports
 
+  # ── 阶段 2：单元测试（等待阶段 1 全部通过）──
+
   unit-test:
     name: Unit Tests
     needs: [lint, mypy, lint-imports]
@@ -133,6 +105,8 @@ jobs:
         with:
           name: junit-unit-${{ matrix.os }}
           path: junit-unit.xml
+
+  # ── 阶段 3：真实 CLI 集成测试（需要自托管 Mac）──
 
   cli-integration:
     name: CLI Integration Tests
@@ -166,6 +140,8 @@ jobs:
         with:
           name: junit-integration
           path: junit-integration.xml
+
+  # ── Job Summary ──
 
   summary:
     name: PR Check Summary

--- a/src/sts2_autotest/__init__.py
+++ b/src/sts2_autotest/__init__.py
@@ -2,12 +2,12 @@
 
 __version__ = "0.1.0"
 
-from sts2_autotest.common import GameScreen, GameState, STS2Error, Capabilities
+from sts2_autotest.common import Capabilities, GameScreen, GameState, STS2Error
 
 __all__ = [
-    "__version__",
+    "Capabilities",
     "GameScreen",
     "GameState",
     "STS2Error",
-    "Capabilities",
+    "__version__",
 ]

--- a/src/sts2_autotest/adapters/__init__.py
+++ b/src/sts2_autotest/adapters/__init__.py
@@ -9,9 +9,9 @@ from sts2_autotest.adapters.cli_mod import CliModAdapter
 from sts2_autotest.adapters.discovery import discover_sts2_cli
 
 __all__ = [
-    "GameAdapterProtocol",
     "ActionResult",
-    "HealthStatus",
     "CliModAdapter",
+    "GameAdapterProtocol",
+    "HealthStatus",
     "discover_sts2_cli",
 ]

--- a/src/sts2_autotest/cli/main.py
+++ b/src/sts2_autotest/cli/main.py
@@ -12,9 +12,9 @@ import json
 import os
 import platform
 import shutil
-import time
 import subprocess
 import sys
+import time
 import zipfile
 from datetime import datetime, timezone
 from pathlib import Path
@@ -22,6 +22,11 @@ from typing import Any, Callable, Literal, Sequence, cast
 
 from sts2_autotest.adapters.base import GameAdapterProtocol
 from sts2_autotest.cli import mcp_server
+from sts2_autotest.common.visual_qa import (
+    DEFAULT_HIGH_BRIGHTNESS_THRESHOLD,
+    DEFAULT_LOW_BRIGHTNESS_THRESHOLD,
+    DEFAULT_LOW_VARIANCE_THRESHOLD,
+)
 from sts2_autotest.core.visual_qa import (
     DisabledOcrProvider,
     OcrProvider,
@@ -30,13 +35,7 @@ from sts2_autotest.core.visual_qa import (
     VisualQaEngine,
     build_visual_qa_payload,
 )
-from sts2_autotest.common.visual_qa import (
-    DEFAULT_HIGH_BRIGHTNESS_THRESHOLD,
-    DEFAULT_LOW_BRIGHTNESS_THRESHOLD,
-    DEFAULT_LOW_VARIANCE_THRESHOLD,
-)
 from sts2_autotest.report_html import write_html_report
-
 
 DEFAULT_EVIDENCE_DIR = "tests/output"
 
@@ -968,11 +967,11 @@ def _run_orchestrator_with_adapter(
 
     Lifecycle is owned by run_all() (start_session + stop_session inside).
     """
+    from sts2_autotest.core.evidence_hooks import build_evidence_hooks
     from sts2_autotest.core.orchestrator import TestOrchestrator
     from sts2_autotest.core.recovery import DefaultRecoveryStrategy
-    from sts2_autotest.core.steam import SteamController
     from sts2_autotest.core.runtime_factory import build_lifecycle_manager
-    from sts2_autotest.core.evidence_hooks import build_evidence_hooks
+    from sts2_autotest.core.steam import SteamController
 
     steam = SteamController(startup_timeout=60.0)
     recreate_factory = adapter_factory or (lambda: _create_adapter("cli"))
@@ -1320,8 +1319,8 @@ def review_cmd(args: Any) -> int:
 
 def compile_cmd(args: Any) -> int:
     """Compile specs to pytest test files."""
-    from sts2_autotest.core.markdown_parser import MarkdownParser
     from sts2_autotest.core.code_generator import CodeGenerator
+    from sts2_autotest.core.markdown_parser import MarkdownParser
 
     try:
         spec_dir = _resolve_spec_dir(args)
@@ -1684,7 +1683,11 @@ def run_cmd(args: Any) -> int:
     if not internal_run_id:
         return _run_cmd_foreground(args)
 
-    from sts2_autotest.core.run_service import RunCancelled, complete_record, wait_for_turn
+    from sts2_autotest.core.run_service import (
+        RunCancelled,
+        complete_record,
+        wait_for_turn,
+    )
 
     store = _run_store()
     try:
@@ -2158,14 +2161,14 @@ def _run_journey_foreground(
     仅设置了 STS2_GAME_DIR（无实际游戏进程）的环境里被预检误拦。
     """
     from sts2_autotest.common.errors import STS2Error
+    from sts2_autotest.core.action_model import TestResult
+    from sts2_autotest.core.evidence_hooks import build_evidence_hooks
     from sts2_autotest.core.journeys import (
         GenericJourneys,
         JourneyCancelled,
         JourneyFailure,
         _extract_chapter,
     )
-    from sts2_autotest.core.evidence_hooks import build_evidence_hooks
-    from sts2_autotest.core.action_model import TestResult
 
     case_id = f"journey:{journey}"
     evidence_root = Path(
@@ -2177,8 +2180,8 @@ def _run_journey_foreground(
     # 取消收尾（审查结论 #5）在局内取消且 reset 失败时需要 lifecycle 的受控
     # 重启能力回到主菜单。此处构建管理器（仅封装，不启进程）；若环境无法定位
     # 游戏目录则置 None，取消收尾会据此跳过受控重启并归类为清理失败。
-    from sts2_autotest.core.steam import SteamController
     from sts2_autotest.core.runtime_factory import build_lifecycle_manager
+    from sts2_autotest.core.steam import SteamController
 
     lifecycle: Any = None
     steam = SteamController(startup_timeout=60.0)

--- a/src/sts2_autotest/cli/mcp_protocol.py
+++ b/src/sts2_autotest/cli/mcp_protocol.py
@@ -11,7 +11,6 @@ import json
 from dataclasses import dataclass, field
 from typing import Any
 
-
 # Stable protocol version used by the cross-agent service. The server keeps
 # the old JSON-RPC shape for existing local clients while exposing the newer
 # transport/version contract to new clients.

--- a/src/sts2_autotest/cli/mcp_server.py
+++ b/src/sts2_autotest/cli/mcp_server.py
@@ -15,12 +15,12 @@ import sys
 from typing import Any, cast
 
 from sts2_autotest.cli.health_server import (
-    _HttpServer,
-    _json_response,
     _HTML_200,
     _HTML_404,
     _HTML_405,
     _HTML_500,
+    _HttpServer,
+    _json_response,
 )
 from sts2_autotest.cli.mcp_protocol import (
     INTERNAL_ERROR,

--- a/src/sts2_autotest/cli/mcp_tools.py
+++ b/src/sts2_autotest/cli/mcp_tools.py
@@ -3,16 +3,16 @@
 from __future__ import annotations
 
 import asyncio
-import os
 import json
+import os
 import re
 import shutil
 import subprocess
 import sys
 import threading
 import time
-import xml.etree.ElementTree as ET
 import uuid
+import xml.etree.ElementTree as ET
 import zipfile
 from collections.abc import Callable
 from datetime import datetime, timezone
@@ -909,11 +909,11 @@ def _resolve_and_validate_project(args: dict[str, Any]) -> Path | None:
     project = args.get("project")
     if not isinstance(project, str) or not project:
         return None
-    from sts2_autotest.cli.main import _resolve_project_base_dir
     from sts2_autotest.adapters.project_extension import (
         find_project_config_file,
         load_project_spec_output,
     )
+    from sts2_autotest.cli.main import _resolve_project_base_dir
 
     base_dir = _resolve_project_base_dir(project)
     if base_dir is None:

--- a/src/sts2_autotest/common/__init__.py
+++ b/src/sts2_autotest/common/__init__.py
@@ -4,15 +4,19 @@ This is the ONLY shared cross-module layer. No module imports another
 module except through common/. Enforced by import-linter.
 """
 
-from sts2_autotest.common.state import GameScreen, GameState
 from sts2_autotest.common.errors import STS2Error
-from sts2_autotest.common.types import Capabilities, CaptureResult, ScreenCaptureProtocol
+from sts2_autotest.common.state import GameScreen, GameState
+from sts2_autotest.common.types import (
+    Capabilities,
+    CaptureResult,
+    ScreenCaptureProtocol,
+)
 
 __all__ = [
+    "Capabilities",
+    "CaptureResult",
     "GameScreen",
     "GameState",
     "STS2Error",
-    "Capabilities",
-    "CaptureResult",
     "ScreenCaptureProtocol",
 ]

--- a/src/sts2_autotest/common/evidence.py
+++ b/src/sts2_autotest/common/evidence.py
@@ -3,8 +3,8 @@
 from typing import Any, Literal
 
 from pydantic import BaseModel, ConfigDict, Field
-from sts2_autotest.common.errors import FailureClassification
 
+from sts2_autotest.common.errors import FailureClassification
 
 SCHEMA_VERSION = "1.0.0"
 

--- a/src/sts2_autotest/common/state.py
+++ b/src/sts2_autotest/common/state.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from enum import StrEnum
+
 from pydantic import BaseModel, ConfigDict
 
 

--- a/src/sts2_autotest/common/visual_qa.py
+++ b/src/sts2_autotest/common/visual_qa.py
@@ -6,7 +6,6 @@ from typing import Literal
 
 from pydantic import BaseModel, ConfigDict, Field
 
-
 DEFAULT_LOW_VARIANCE_THRESHOLD = 1.0
 DEFAULT_LOW_BRIGHTNESS_THRESHOLD = 5.0
 DEFAULT_HIGH_BRIGHTNESS_THRESHOLD = 250.0

--- a/src/sts2_autotest/config/__init__.py
+++ b/src/sts2_autotest/config/__init__.py
@@ -5,7 +5,7 @@ from sts2_autotest.config.loader import load_config
 from sts2_autotest.config.schema import STS2Config
 
 __all__ = [
+    "ConfigValidationError",
     "STS2Config",
     "load_config",
-    "ConfigValidationError",
 ]

--- a/src/sts2_autotest/config/loader.py
+++ b/src/sts2_autotest/config/loader.py
@@ -189,6 +189,7 @@ def load_config(
         return STS2Config(**merged)
     except Exception as exc:
         from pydantic import ValidationError as PydanticVE
+
         from sts2_autotest.config.errors import ConfigValidationError
 
         if isinstance(exc, PydanticVE):

--- a/src/sts2_autotest/core/__init__.py
+++ b/src/sts2_autotest/core/__init__.py
@@ -2,8 +2,8 @@
 
 from sts2_autotest.core.action_model import ActionDescriptor, TestResult
 from sts2_autotest.core.evidence_hooks import RealEvidenceHooks, StubEvidenceHooks
-from sts2_autotest.core.lifecycle import GameLifecycleManager
 from sts2_autotest.core.journeys import GenericJourneys, JourneyFailure
+from sts2_autotest.core.lifecycle import GameLifecycleManager
 from sts2_autotest.core.orchestrator import SessionSummary, TestOrchestrator
 from sts2_autotest.core.run_service import RunRecord, RunRequest, RunStore
 from sts2_autotest.core.state_engine import StateEngine, StateTransitionError

--- a/src/sts2_autotest/core/case_registry.py
+++ b/src/sts2_autotest/core/case_registry.py
@@ -17,7 +17,6 @@ from typing import Awaitable, Callable
 from sts2_autotest.core.action_model import ActionDescriptor, TestResult
 from sts2_autotest.core.orchestrator import TestOrchestrator
 
-
 # Type alias for programmatic case runners
 CaseRunner = Callable[[TestOrchestrator], Awaitable[TestResult]]
 

--- a/src/sts2_autotest/core/code_generator.py
+++ b/src/sts2_autotest/core/code_generator.py
@@ -6,8 +6,8 @@ main chain (FluentBuilder -> ActionDescriptor -> Orchestrator).
 
 from __future__ import annotations
 
-import re
 import json
+import re
 from pathlib import Path
 
 from sts2_autotest.common.spec_models import SuiteSpec, TestSpec
@@ -310,7 +310,7 @@ class CodeGenerator:
                 [
                     f"def test_{func_name}():",
                     f'    """{spec.title}"""',
-                    f'    pytest.skip("No steps defined")',
+                    '    pytest.skip("No steps defined")',
                 ]
             )
 

--- a/src/sts2_autotest/core/lifecycle.py
+++ b/src/sts2_autotest/core/lifecycle.py
@@ -28,8 +28,9 @@ import socket
 import subprocess
 import sys
 import time
+from collections.abc import Callable
 from dataclasses import dataclass, field
-from typing import IO, Any, Callable
+from typing import IO, Any
 from urllib.parse import urlparse
 
 import psutil

--- a/src/sts2_autotest/core/lifecycle.py
+++ b/src/sts2_autotest/core/lifecycle.py
@@ -29,7 +29,7 @@ import subprocess
 import sys
 import time
 from dataclasses import dataclass, field
-from typing import Any, Callable, IO
+from typing import IO, Any, Callable
 from urllib.parse import urlparse
 
 import psutil

--- a/src/sts2_autotest/core/markdown_parser.py
+++ b/src/sts2_autotest/core/markdown_parser.py
@@ -11,7 +11,7 @@ import re
 from pathlib import Path
 from typing import Optional
 
-from sts2_autotest.common.spec_models import TestSpec, SuiteSpec
+from sts2_autotest.common.spec_models import SuiteSpec, TestSpec
 
 
 class ParsingError(ValueError):

--- a/src/sts2_autotest/core/orchestrator.py
+++ b/src/sts2_autotest/core/orchestrator.py
@@ -11,13 +11,13 @@ from sts2_autotest.adapters.base import ActionResult, GameAdapterProtocol
 from sts2_autotest.common.errors import ErrorCategory, STS2Error
 from sts2_autotest.common.logging import get_logger
 from sts2_autotest.common.state import GameScreen, GameState
+from sts2_autotest.common.types import SessionStatus
 from sts2_autotest.core.action_model import ActionDescriptor, TestResult
 from sts2_autotest.core.data_validator import validate_game_state
+from sts2_autotest.core.evidence_hooks import EvidenceHooks, StubEvidenceHooks
 from sts2_autotest.core.lock_manager import LockManager
 from sts2_autotest.core.navigation import NavigationBlocked, progress_until
 from sts2_autotest.core.progress import ProgressRecord, clear_progress, save_progress
-from sts2_autotest.core.evidence_hooks import EvidenceHooks, StubEvidenceHooks
-from sts2_autotest.common.types import SessionStatus
 from sts2_autotest.core.recovery import (
     DefaultRecoveryStrategy,
     FailureRecord,
@@ -26,8 +26,8 @@ from sts2_autotest.core.recovery import (
     crash_signature,
     is_p0_exception,
 )
-from sts2_autotest.core.steam import SteamController
 from sts2_autotest.core.state_engine import StateEngine, StateTransitionError
+from sts2_autotest.core.steam import SteamController
 from sts2_autotest.core.watchdog import Watchdog
 
 logger = get_logger("core.orchestrator")

--- a/src/sts2_autotest/core/repair_advisor.py
+++ b/src/sts2_autotest/core/repair_advisor.py
@@ -13,14 +13,13 @@ import traceback
 from datetime import datetime, timezone
 from typing import TYPE_CHECKING
 
-from sts2_autotest.common.errors import ErrorCategory
+from sts2_autotest.common.errors import ErrorCategory, FailureClassification
 from sts2_autotest.common.evidence import (
     FailureInfo,
     RepairReport,
     RepairSuggestion,
     SummaryJson,
 )
-from sts2_autotest.common.errors import FailureClassification
 from sts2_autotest.common.logging import get_logger
 
 if TYPE_CHECKING:

--- a/src/sts2_autotest/core/run_service.py
+++ b/src/sts2_autotest/core/run_service.py
@@ -6,10 +6,10 @@ Gawain 业务规则，只负责任务生命周期、持久化、排队和控制�
 
 from __future__ import annotations
 
-import json
-import os
 import builtins
 import importlib
+import json
+import os
 import signal
 import subprocess
 import sys

--- a/src/sts2_autotest/core/spec_reviewer.py
+++ b/src/sts2_autotest/core/spec_reviewer.py
@@ -8,10 +8,13 @@ from __future__ import annotations
 import re
 
 from sts2_autotest.common.spec_models import (
-    TestSpec, SuiteSpec, ReviewReport, RevisedDraft,
-    ReviewIssue, IssueCategory,
+    IssueCategory,
+    ReviewIssue,
+    ReviewReport,
+    RevisedDraft,
+    SuiteSpec,
+    TestSpec,
 )
-
 
 # Ambiguous Chinese phrases that signal unclear test steps
 _AMBIGUITY_PATTERNS: list[tuple[str, str]] = [
@@ -219,7 +222,7 @@ class SpecReviewer:
         lines = [f"# {spec.id} {spec.title}", ""]
         lines.append("## Metadata")
         lines.append(f"- id: {spec.id}")
-        lines.append(f"- level: case")
+        lines.append("- level: case")
         if spec.tags:
             lines.append(f"- tags: {', '.join(spec.tags)}")
         lines.append(f"- priority: {spec.priority}")

--- a/src/sts2_autotest/core/test_agent_runner.py
+++ b/src/sts2_autotest/core/test_agent_runner.py
@@ -11,6 +11,10 @@ Exit codes (matching ROLE_TESTER convention):
 
 from __future__ import annotations
 
+import asyncio
+import importlib
+import inspect
+import json
 import os
 import platform
 import re
@@ -18,13 +22,10 @@ import shutil
 import subprocess
 import sys
 import time
-import asyncio
-import inspect
-import importlib
-import json
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
+
 from sts2_autotest.adapters.agent import AgentAdapter
 from sts2_autotest.common.visual_qa import ScreenshotOcrAnalysis
 from sts2_autotest.core.steam import SteamController
@@ -220,7 +221,10 @@ def _capture_macos_window_png(path: Path, window_title: str) -> bool:
     """Capture a specific macOS window directly into a PNG file."""
     try:
         import Quartz
-        from AppKit import NSBitmapImageRep, NSPNGFileType  # type: ignore[import-not-found]
+        from AppKit import (  # type: ignore[import-not-found]
+            NSBitmapImageRep,
+            NSPNGFileType,
+        )
     except Exception:
         selector_source = inspect.getsource(_normalize_window_token) + "\n\n" + inspect.getsource(_select_macos_window)
         script = f"""

--- a/src/sts2_autotest/core/visual_qa.py
+++ b/src/sts2_autotest/core/visual_qa.py
@@ -12,8 +12,14 @@ from typing import Any, Literal, Protocol, cast
 
 from sts2_autotest.common.visual_qa import (
     DEFAULT_HIGH_BRIGHTNESS_THRESHOLD as _DEFAULT_HIGH_BRIGHTNESS_THRESHOLD,
+)
+from sts2_autotest.common.visual_qa import (
     DEFAULT_LOW_BRIGHTNESS_THRESHOLD as _DEFAULT_LOW_BRIGHTNESS_THRESHOLD,
+)
+from sts2_autotest.common.visual_qa import (
     DEFAULT_LOW_VARIANCE_THRESHOLD as _DEFAULT_LOW_VARIANCE_THRESHOLD,
+)
+from sts2_autotest.common.visual_qa import (
     OcrTextBlock,
     ScreenshotOcrAnalysis,
     VisualQaFinding,

--- a/src/sts2_autotest/dsl/__init__.py
+++ b/src/sts2_autotest/dsl/__init__.py
@@ -1,5 +1,4 @@
 """DSL package — fluent API for authoring test cases."""
-from sts2_autotest.dsl.fluent import FluentBuilder, HandlerFn, define
 from sts2_autotest.dsl.assertions import (
     advance_dialogue,
     choose_event,
@@ -30,11 +29,12 @@ from sts2_autotest.dsl.assertions import (
     start_new_run,
 )
 from sts2_autotest.dsl.fixtures import FixtureLoader
+from sts2_autotest.dsl.fluent import FluentBuilder, HandlerFn, define
 from sts2_autotest.dsl.handlers import capture_screenshot, log_state
 
 __all__ = [
-    "FluentBuilder",
     "FixtureLoader",
+    "FluentBuilder",
     "HandlerFn",
     "advance_dialogue",
     "capture_screenshot",
@@ -52,8 +52,8 @@ __all__ = [
     "give_card",
     "hand_size_changed_by",
     "has_travelable_node",
-    "minion_queue_ids_are",
     "log_state",
+    "minion_queue_ids_are",
     "no_crash_detected",
     "play_card",
     "player_block_increased_by",

--- a/src/sts2_autotest/dsl/assertions.py
+++ b/src/sts2_autotest/dsl/assertions.py
@@ -98,7 +98,7 @@ def enemy_hp_decreased_by(amount: int) -> AssertionFn:
         current = _resolve_enemy_field(state, "hp")
         previous = getattr(state, "previous_enemy_hp", None)
         if previous is None:
-            return False, f"previous_enemy_hp not in state, cannot verify decrease"
+            return False, "previous_enemy_hp not in state, cannot verify decrease"
         actual = previous - current if current is not None else 0
         ok = actual >= amount  # >= because RNG can cause extra damage
         msg = "" if ok else f"Expected enemy HP decrease ≥ {amount}, got {actual}"
@@ -142,7 +142,7 @@ def player_energy_decreased_by(amount: int) -> AssertionFn:
         current = _resolve_player_field(state, "energy")
         previous = getattr(state, "previous_energy", None)
         if previous is None:
-            return False, f"previous_energy not in state, cannot verify decrease"
+            return False, "previous_energy not in state, cannot verify decrease"
         actual = previous - current if current is not None else 0
         ok = actual == amount
         msg = "" if ok else f"Expected energy decrease {amount}, got {actual}"
@@ -158,7 +158,7 @@ def player_hp_changed_by(amount: int) -> AssertionFn:
         current = _resolve_player_field(state, "hp")
         previous = getattr(state, "previous_hp", None)
         if previous is None:
-            return False, f"previous_hp not in state, cannot verify change"
+            return False, "previous_hp not in state, cannot verify change"
         actual = current - previous if current is not None else 0
         ok = actual == amount
         msg = "" if ok else f"Expected HP change {amount}, got {actual}"
@@ -174,7 +174,7 @@ def player_block_increased_by(amount: int) -> AssertionFn:
         current = _resolve_player_field(state, "block")
         previous = getattr(state, "previous_block", None)
         if previous is None:
-            return False, f"previous_block not in state, cannot verify increase"
+            return False, "previous_block not in state, cannot verify increase"
         actual = current - previous if current is not None else 0
         ok = actual == amount
         msg = "" if ok else f"Expected block increase {amount}, got {actual}"
@@ -190,7 +190,7 @@ def hand_size_changed_by(amount: int) -> AssertionFn:
         current = _resolve_player_field(state, "hand_count")
         previous = getattr(state, "previous_hand_count", None)
         if previous is None:
-            return False, f"previous_hand_count not in state, cannot verify change"
+            return False, "previous_hand_count not in state, cannot verify change"
         actual = current - previous if current is not None else 0
         ok = actual == amount
         msg = "" if ok else f"Expected hand size change {amount}, got {actual}"
@@ -323,7 +323,7 @@ def no_crash_detected() -> AssertionFn:
 
     def check(state: GameState) -> tuple[bool, str]:
         ok = state.screen != GameScreen.CRASHED
-        msg = "" if ok else f"Game is in CRASHED state"
+        msg = "" if ok else "Game is in CRASHED state"
         return ok, msg
 
     return check

--- a/src/sts2_autotest/dsl/fluent.py
+++ b/src/sts2_autotest/dsl/fluent.py
@@ -9,13 +9,13 @@ from __future__ import annotations
 __test__ = False
 
 import asyncio
-from dataclasses import dataclass
 import inspect
 import json
 import os
-from pathlib import Path
 import re
 import time
+from dataclasses import dataclass
+from pathlib import Path
 from typing import Any, Callable
 
 from sts2_autotest.adapters.base import ActionResult

--- a/src/sts2_autotest/evidence/__init__.py
+++ b/src/sts2_autotest/evidence/__init__.py
@@ -1,14 +1,14 @@
 """Evidence & observability package for STS2-AUTOTEST."""
 
 from sts2_autotest.evidence.capture import ScreenCapture
-from sts2_autotest.evidence.logs import LogCollector, LogCollectionResult
+from sts2_autotest.evidence.logs import LogCollectionResult, LogCollector
 from sts2_autotest.evidence.metrics import MetricEvent, MetricsCollector
 from sts2_autotest.evidence.packager import EvidencePackager
 
 __all__ = [
     "EvidencePackager",
-    "LogCollector",
     "LogCollectionResult",
+    "LogCollector",
     "MetricEvent",
     "MetricsCollector",
     "ScreenCapture",

--- a/src/sts2_autotest/pytest_plugin/__init__.py
+++ b/src/sts2_autotest/pytest_plugin/__init__.py
@@ -9,12 +9,12 @@ from sts2_autotest.pytest_plugin.fixtures import (
 from sts2_autotest.pytest_plugin.hooks import HookFn, clear, fire, register
 
 __all__ = [
-    "autotest",
-    "game_state",
     "HookFn",
     "SessionInitError",
     "UserError",
+    "autotest",
     "clear",
     "fire",
+    "game_state",
     "register",
 ]

--- a/src/sts2_autotest/pytest_plugin/fixtures.py
+++ b/src/sts2_autotest/pytest_plugin/fixtures.py
@@ -14,8 +14,8 @@ from typing import Any, Callable, Generator
 import pytest
 
 from sts2_autotest.adapters.base import GameAdapterProtocol
-from sts2_autotest.adapters.discovery import find_game_dir, steam_roots
 from sts2_autotest.adapters.cli_mod import CliModAdapter
+from sts2_autotest.adapters.discovery import find_game_dir, steam_roots
 from sts2_autotest.common.logging import get_logger
 from sts2_autotest.common.state import GameState
 from sts2_autotest.core.evidence_hooks import build_evidence_hooks

--- a/src/sts2_autotest/pytest_plugin/plugin.py
+++ b/src/sts2_autotest/pytest_plugin/plugin.py
@@ -275,8 +275,8 @@ def pytest_sessionfinish(session: pytest.Session, exitstatus: int) -> None:
 
 
 __all__ = [
+    "_orchestrator",
+    "_session_loop",
     "autotest",
     "game_state",
-    "_session_loop",
-    "_orchestrator",
 ]

--- a/tests/e2e_crash_recovery.py
+++ b/tests/e2e_crash_recovery.py
@@ -25,10 +25,10 @@ import pytest
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 
 from sts2_autotest.adapters.base import ActionResult, GameAdapterProtocol, HealthStatus
+from sts2_autotest.common.errors import ErrorCategory, STS2Error
+from sts2_autotest.common.state import GameScreen, GameState
 from sts2_autotest.core.orchestrator import TestOrchestrator
 from sts2_autotest.core.recovery import DefaultRecoveryStrategy, FailureRecord
-from sts2_autotest.common.state import GameScreen, GameState
-from sts2_autotest.common.errors import STS2Error, ErrorCategory
 
 
 def _run(coro: Any) -> Any:

--- a/tests/generated/ironclad-twin-strike/run_current_state_probe.py
+++ b/tests/generated/ironclad-twin-strike/run_current_state_probe.py
@@ -9,7 +9,6 @@ from typing import Any
 
 from sts2_autotest.adapters.cli_mod import CliModAdapter
 
-
 OUTPUT = Path("tests/output/ironclad-twin-strike/current-state-probe.json")
 
 

--- a/tests/generated/ironclad-twin-strike/test_suite_ironclad_twin_strike_damage.py
+++ b/tests/generated/ironclad-twin-strike/test_suite_ironclad_twin_strike_damage.py
@@ -1,8 +1,7 @@
 import json
 from pathlib import Path
 
-
-from sts2_autotest.dsl.fluent import define
+from sts2_autotest.common.state import GameScreen
 from sts2_autotest.dsl.assertions import (
     choose_event,
     choose_map_node,
@@ -17,7 +16,8 @@ from sts2_autotest.dsl.assertions import (
     select_character,
     start_new_run,
 )
-from sts2_autotest.common.state import GameScreen
+from sts2_autotest.dsl.fluent import define
+
 
 def test_suite_ironclad_twin_strike_damage(autotest, _session_loop):
     """战士双重打击真实流程验证"""

--- a/tests/generated/ironclad-twin-strike/test_tc_ironclad_twin_strike_damage.py
+++ b/tests/generated/ironclad-twin-strike/test_tc_ironclad_twin_strike_damage.py
@@ -1,7 +1,6 @@
 import json
 
-
-from sts2_autotest.dsl.fluent import define
+from sts2_autotest.common.state import GameScreen
 from sts2_autotest.dsl.assertions import (
     choose_event,
     choose_map_node,
@@ -16,7 +15,8 @@ from sts2_autotest.dsl.assertions import (
     select_character,
     start_new_run,
 )
-from sts2_autotest.common.state import GameScreen
+from sts2_autotest.dsl.fluent import define
+
 
 # Given: 已安装并可连接 STS2-Cli-Mod
 # Given: 游戏可被启动并加载到主菜单

--- a/tests/generated/test_suite_first_battle_smoke.py
+++ b/tests/generated/test_suite_first_battle_smoke.py
@@ -1,6 +1,7 @@
 import json
 from pathlib import Path
-from sts2_autotest.dsl.fluent import define
+
+from sts2_autotest.common.state import GameScreen
 from sts2_autotest.dsl.assertions import (
     advance_dialogue,
     choose_event,
@@ -9,14 +10,15 @@ from sts2_autotest.dsl.assertions import (
     embark,
     enter_combat,
     game_reached_state,
-    no_crash_detected,
     has_travelable_node,
+    no_crash_detected,
     return_to_menu,
     select_character,
     skip_card_reward,
     start_new_run,
 )
-from sts2_autotest.common.state import GameScreen
+from sts2_autotest.dsl.fluent import define
+
 
 def test_suite_first_battle_smoke(autotest, _session_loop):
     """首次战斗冒烟"""

--- a/tests/generated/test_suite_ironclad_twin_strike_damage.py
+++ b/tests/generated/test_suite_ironclad_twin_strike_damage.py
@@ -1,6 +1,7 @@
 import json
 from pathlib import Path
-from sts2_autotest.dsl.fluent import define
+
+from sts2_autotest.common.state import GameScreen
 from sts2_autotest.dsl.assertions import (
     choose_event,
     choose_map_node,
@@ -15,7 +16,8 @@ from sts2_autotest.dsl.assertions import (
     select_character,
     start_new_run,
 )
-from sts2_autotest.common.state import GameScreen
+from sts2_autotest.dsl.fluent import define
+
 
 def test_suite_ironclad_twin_strike_damage(autotest, _session_loop):
     """战士双重打击真实流程验证"""

--- a/tests/generated/test_tc_finish_first_battle.py
+++ b/tests/generated/test_tc_finish_first_battle.py
@@ -1,5 +1,6 @@
 import json
-from sts2_autotest.dsl.fluent import define
+
+from sts2_autotest.common.state import GameScreen
 from sts2_autotest.dsl.assertions import (
     choose_map_node,
     combat_basic_policy,
@@ -8,7 +9,8 @@ from sts2_autotest.dsl.assertions import (
     no_crash_detected,
     skip_card_reward,
 )
-from sts2_autotest.common.state import GameScreen
+from sts2_autotest.dsl.fluent import define
+
 
 # Given: 已安装并可连接 STS2-Cli-Mod
 # Given: 首次战斗节点可被选择

--- a/tests/generated/test_tc_ironclad_twin_strike_damage.py
+++ b/tests/generated/test_tc_ironclad_twin_strike_damage.py
@@ -1,5 +1,6 @@
 import json
-from sts2_autotest.dsl.fluent import define
+
+from sts2_autotest.common.state import GameScreen
 from sts2_autotest.dsl.assertions import (
     choose_event,
     choose_map_node,
@@ -14,7 +15,8 @@ from sts2_autotest.dsl.assertions import (
     select_character,
     start_new_run,
 )
-from sts2_autotest.common.state import GameScreen
+from sts2_autotest.dsl.fluent import define
+
 
 # Given: 已安装并可连接 STS2-Cli-Mod
 # Given: 游戏可被启动并加载到主菜单

--- a/tests/generated/test_tc_prepare_new_run.py
+++ b/tests/generated/test_tc_prepare_new_run.py
@@ -1,16 +1,18 @@
 import json
-from sts2_autotest.dsl.fluent import define
+
+from sts2_autotest.common.state import GameScreen
 from sts2_autotest.dsl.assertions import (
     advance_dialogue,
     embark,
     game_reached_state,
-    no_crash_detected,
     has_travelable_node,
+    no_crash_detected,
     return_to_menu,
     select_character,
     start_new_run,
 )
-from sts2_autotest.common.state import GameScreen
+from sts2_autotest.dsl.fluent import define
+
 
 # Given: 已安装并可连接 STS2-Cli-Mod
 # Given: 游戏可被启动

--- a/tests/generated/test_tc_resolve_neow.py
+++ b/tests/generated/test_tc_resolve_neow.py
@@ -1,12 +1,14 @@
 import json
-from sts2_autotest.dsl.fluent import define
+
+from sts2_autotest.common.state import GameScreen
 from sts2_autotest.dsl.assertions import (
     choose_event,
     game_reached_state,
-    no_crash_detected,
     has_travelable_node,
+    no_crash_detected,
 )
-from sts2_autotest.common.state import GameScreen
+from sts2_autotest.dsl.fluent import define
+
 
 # Given: 已安装并可连接 STS2-Cli-Mod
 # Given: 当前事件为开局祝福事件

--- a/tests/integration/test_cli_mod_cli_only.py
+++ b/tests/integration/test_cli_mod_cli_only.py
@@ -16,7 +16,6 @@ from sts2_autotest.common.errors import ErrorCategory, STS2Error
 
 from .conftest import _run
 
-
 pytestmark = pytest.mark.integration
 
 

--- a/tests/integration/test_cli_mod_game_smoke.py
+++ b/tests/integration/test_cli_mod_game_smoke.py
@@ -14,7 +14,6 @@ from sts2_autotest.common.state import GameScreen, GameState
 
 from .conftest import _run
 
-
 pytestmark = [pytest.mark.integration, pytest.mark.requires_game]
 
 

--- a/tests/integration/test_spec_pipeline_e2e.py
+++ b/tests/integration/test_spec_pipeline_e2e.py
@@ -10,10 +10,9 @@ from pathlib import Path
 
 import pytest
 
+from sts2_autotest.core.code_generator import CodeGenerator
 from sts2_autotest.core.markdown_parser import MarkdownParser
 from sts2_autotest.core.spec_reviewer import SpecReviewer
-from sts2_autotest.core.code_generator import CodeGenerator
-
 
 SAMPLE_CASE = """\
 # TC-PREPARE-NEW-RUN 进入新局地图

--- a/tests/unit/test_capture.py
+++ b/tests/unit/test_capture.py
@@ -18,7 +18,6 @@ from sts2_autotest.evidence.capture import (
     _restore_window,
 )
 
-
 # ── Helpers ──────────────────────────────────────────────────
 
 
@@ -725,8 +724,8 @@ class TestFrameworkConfigScreenshot:
 
 class TestRealEvidenceHooks:
     def test_on_case_end_captures(self) -> None:
-        from sts2_autotest.core.evidence_hooks import RealEvidenceHooks
         from sts2_autotest.core.action_model import TestResult
+        from sts2_autotest.core.evidence_hooks import RealEvidenceHooks
 
         mock_capture = MagicMock()
         mock_capture.capture_with_validation.return_value = CaptureResult(
@@ -740,8 +739,8 @@ class TestRealEvidenceHooks:
         mock_capture.capture_with_validation.assert_called_once_with("TestGame", "test-1")
 
     def test_on_case_end_skipped(self) -> None:
-        from sts2_autotest.core.evidence_hooks import RealEvidenceHooks
         from sts2_autotest.core.action_model import TestResult
+        from sts2_autotest.core.evidence_hooks import RealEvidenceHooks
 
         mock_capture = MagicMock()
         mock_capture.capture_with_validation.return_value = CaptureResult(
@@ -798,8 +797,8 @@ class TestRealEvidenceHooks:
         )
 
     def test_on_case_end_collects_logs_on_failure(self) -> None:
-        from sts2_autotest.core.evidence_hooks import RealEvidenceHooks
         from sts2_autotest.core.action_model import TestResult
+        from sts2_autotest.core.evidence_hooks import RealEvidenceHooks
 
         mock_capture = MagicMock()
         mock_capture.capture_with_validation.return_value = CaptureResult(status="ok", path=Path("/tmp/s.png"))
@@ -825,8 +824,8 @@ class TestRealEvidenceHooks:
 
 class TestCaptureScreenshotHandler:
     def test_with_real_evidence_hooks(self) -> None:
-        from sts2_autotest.dsl.handlers import capture_screenshot
         from sts2_autotest.core.orchestrator import TestOrchestrator
+        from sts2_autotest.dsl.handlers import capture_screenshot
 
         mock_capture = MagicMock()
         mock_capture.capture_with_validation.return_value = CaptureResult(
@@ -844,9 +843,9 @@ class TestCaptureScreenshotHandler:
         mock_capture.capture_with_validation.assert_called_once()
 
     def test_without_capture_fallback(self) -> None:
-        from sts2_autotest.dsl.handlers import capture_screenshot
         from sts2_autotest.core.evidence_hooks import StubEvidenceHooks
         from sts2_autotest.core.orchestrator import TestOrchestrator
+        from sts2_autotest.dsl.handlers import capture_screenshot
 
         mock_adapter = MagicMock()
         stub_hooks = StubEvidenceHooks()

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -1,7 +1,7 @@
 """Tests for cli/main.py — CLI entry points."""
 
-import os
 import json
+import os
 import subprocess
 import sys
 from pathlib import Path

--- a/tests/unit/test_cli_discovery.py
+++ b/tests/unit/test_cli_discovery.py
@@ -3,7 +3,6 @@
 import os
 from unittest.mock import patch
 
-
 from sts2_autotest.adapters.discovery import discover_sts2_cli
 
 

--- a/tests/unit/test_cli_spec_commands.py
+++ b/tests/unit/test_cli_spec_commands.py
@@ -1,14 +1,16 @@
 """Tests for CLI spec pipeline commands (review, compile, run --all)."""
 from __future__ import annotations
 
-import pytest
-from pathlib import Path
 from argparse import Namespace
+from pathlib import Path
+
+import pytest
+
 from sts2_autotest.cli.main import (
-    review_cmd,
-    compile_cmd,
     _create_parser,
     _ensure_output_dir_writable,
+    compile_cmd,
+    review_cmd,
 )
 
 

--- a/tests/unit/test_common_evidence.py
+++ b/tests/unit/test_common_evidence.py
@@ -298,6 +298,7 @@ class TestRepairSuggestion:
 
     def test_frozen(self) -> None:
         from pydantic import ValidationError
+
         from sts2_autotest.common.evidence import RepairSuggestion
 
         s = RepairSuggestion(
@@ -308,6 +309,7 @@ class TestRepairSuggestion:
 
     def test_confidence_must_be_float(self) -> None:
         from pydantic import ValidationError
+
         from sts2_autotest.common.evidence import RepairSuggestion
 
         with pytest.raises(ValidationError):
@@ -370,6 +372,7 @@ class TestRepairReport:
 
     def test_frozen(self) -> None:
         from pydantic import ValidationError
+
         from sts2_autotest.common.evidence import RepairReport
 
         r = RepairReport(
@@ -407,7 +410,9 @@ class TestSummaryJsonWithRepairReport:
 
     def test_default_is_none(self) -> None:
         from sts2_autotest.common.evidence import (
-            SummaryJson, RunInfo, EnvironmentInfo,
+            EnvironmentInfo,
+            RunInfo,
+            SummaryJson,
         )
 
         s = SummaryJson(
@@ -426,7 +431,10 @@ class TestSummaryJsonWithRepairReport:
 
     def test_with_repair_report(self) -> None:
         from sts2_autotest.common.evidence import (
-            SummaryJson, RunInfo, EnvironmentInfo, RepairReport,
+            EnvironmentInfo,
+            RepairReport,
+            RunInfo,
+            SummaryJson,
         )
 
         report = RepairReport(
@@ -454,7 +462,11 @@ class TestSummaryJsonWithRepairReport:
 
     def test_roundtrip_with_repair_report(self) -> None:
         from sts2_autotest.common.evidence import (
-            SummaryJson, RunInfo, EnvironmentInfo, RepairReport, RepairSuggestion,
+            EnvironmentInfo,
+            RepairReport,
+            RepairSuggestion,
+            RunInfo,
+            SummaryJson,
         )
 
         suggestion = RepairSuggestion(

--- a/tests/unit/test_config_schema.py
+++ b/tests/unit/test_config_schema.py
@@ -3,6 +3,11 @@
 import pytest
 from pydantic import ValidationError
 
+from sts2_autotest.common.visual_qa import (
+    DEFAULT_HIGH_BRIGHTNESS_THRESHOLD,
+    DEFAULT_LOW_BRIGHTNESS_THRESHOLD,
+    DEFAULT_LOW_VARIANCE_THRESHOLD,
+)
 from sts2_autotest.config.schema import (
     AdapterConfig,
     AgentAdapterConfig,
@@ -10,11 +15,6 @@ from sts2_autotest.config.schema import (
     ExecutionConfig,
     FrameworkConfig,
     STS2Config,
-)
-from sts2_autotest.common.visual_qa import (
-    DEFAULT_HIGH_BRIGHTNESS_THRESHOLD,
-    DEFAULT_LOW_BRIGHTNESS_THRESHOLD,
-    DEFAULT_LOW_VARIANCE_THRESHOLD,
 )
 
 

--- a/tests/unit/test_default_specs.py
+++ b/tests/unit/test_default_specs.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from pathlib import Path
 
+
 def test_default_spec_directories_are_present() -> None:
     assert Path("docs/process/specs/cases").is_dir()
     assert Path("docs/process/specs/suites").is_dir()

--- a/tests/unit/test_dsl_assertions_extended.py
+++ b/tests/unit/test_dsl_assertions_extended.py
@@ -3,7 +3,8 @@ from __future__ import annotations
 
 from sts2_autotest.common.state import GameScreen, GameState
 from sts2_autotest.dsl.assertions import (
-    no_crash_detected, has_travelable_node,
+    has_travelable_node,
+    no_crash_detected,
     player_block_increased_by,
 )
 

--- a/tests/unit/test_e2e_first_battle.py
+++ b/tests/unit/test_e2e_first_battle.py
@@ -9,17 +9,17 @@ from __future__ import annotations
 from sts2_autotest.common.spec_models import TestSpec
 from sts2_autotest.core.code_generator import CodeGenerator
 from tests.e2e_first_battle import (
-    _choose_map_coord,
-    _choose_play_card_args,
-    _is_early_first_battle_state,
-    _is_bootstrap_complete_screen,
     _choose_bootstrap_action,
     _choose_event_progress_action,
+    _choose_grid_card_action,
+    _choose_map_coord,
+    _choose_play_card_args,
     _choose_post_embark_progress_action,
+    _choose_reward_action,
     _choose_tri_card_action,
     _choose_unknown_progress_action,
-    _choose_grid_card_action,
-    _choose_reward_action,
+    _is_bootstrap_complete_screen,
+    _is_early_first_battle_state,
     _is_post_embark_screen,
     _is_recoverable_bootstrap_screen,
 )

--- a/tests/unit/test_evidence_hooks.py
+++ b/tests/unit/test_evidence_hooks.py
@@ -13,7 +13,6 @@ from sts2_autotest.common.types import CaptureResult
 from sts2_autotest.core.action_model import TestResult
 from sts2_autotest.core.evidence_hooks import RealEvidenceHooks
 
-
 # ── Helpers ────────────────────────────────────────────────────
 
 

--- a/tests/unit/test_fluent_api.py
+++ b/tests/unit/test_fluent_api.py
@@ -15,19 +15,19 @@ from sts2_autotest.core.action_model import ActionDescriptor, TestResult
 from sts2_autotest.core.orchestrator import TestOrchestrator
 from sts2_autotest.dsl import define
 from sts2_autotest.dsl.assertions import (
+    choose_event,
     end_turn,
     enemy_hp_decreased_by,
     enemy_took_exact_hits,
     enter_combat,
-    choose_event,
     game_reached_state,
     give_card,
     hand_size_changed_by,
+    minion_queue_ids_are,
     play_card,
     player_block_increased_by,
     player_energy_decreased_by,
     player_hp_changed_by,
-    minion_queue_ids_are,
     set_hp,
     set_seed,
     start_game,

--- a/tests/unit/test_goal_scene_executor.py
+++ b/tests/unit/test_goal_scene_executor.py
@@ -7,7 +7,11 @@ from dataclasses import dataclass
 
 from sts2_autotest.adapters.base import ActionResult
 from sts2_autotest.core.journeys import GenericJourneys, JourneyFailure
-from sts2_autotest.core.navigation import NavigationBlocked, choose_progress_action, progress_until
+from sts2_autotest.core.navigation import (
+    NavigationBlocked,
+    choose_progress_action,
+    progress_until,
+)
 
 
 def test_leftmost_route_uses_horizontal_coordinate_not_list_order() -> None:

--- a/tests/unit/test_lifecycle.py
+++ b/tests/unit/test_lifecycle.py
@@ -436,6 +436,7 @@ class TestEnsureEnvironmentReady:
 def test_game_exe_not_hardcoded_to_user_path():
     """The resolved exe must derive from the provided game_dir, not a literal home path."""
     import inspect
+
     import sts2_autotest.core.lifecycle as lc
     src = inspect.getsource(lc)
     assert "/Users/chris" not in src

--- a/tests/unit/test_lock_manager.py
+++ b/tests/unit/test_lock_manager.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 from pathlib import Path
 from unittest.mock import patch
 
-
 from sts2_autotest.core.lock_manager import LockManager
 
 

--- a/tests/unit/test_logs.py
+++ b/tests/unit/test_logs.py
@@ -10,12 +10,11 @@ from unittest.mock import patch
 import pytest
 
 from sts2_autotest.evidence.logs import (
+    _GODOT_PATTERN,
     LogCollectionResult,
     LogCollector,
     LogEntry,
-    _GODOT_PATTERN,
 )
-
 
 # ── LogEntry / LogCollectionResult ──────────────────────────
 
@@ -804,6 +803,7 @@ class TestFrameworkConfigLog:
 
     def test_invalid_log_max_entries(self) -> None:
         from pydantic import ValidationError
+
         from sts2_autotest.config.schema import FrameworkConfig
 
         with pytest.raises(ValidationError):
@@ -811,6 +811,7 @@ class TestFrameworkConfigLog:
 
     def test_invalid_lock_retries(self) -> None:
         from pydantic import ValidationError
+
         from sts2_autotest.config.schema import FrameworkConfig
 
         with pytest.raises(ValidationError):

--- a/tests/unit/test_markdown_parser.py
+++ b/tests/unit/test_markdown_parser.py
@@ -2,8 +2,11 @@
 from __future__ import annotations
 
 import pytest
+
 from sts2_autotest.core.markdown_parser import (
-    MarkdownParser, ParsingError, detect_level,
+    MarkdownParser,
+    ParsingError,
+    detect_level,
 )
 
 SAMPLE_CASE_MD = """# TC-PREPARE-NEW-RUN 进入新局地图

--- a/tests/unit/test_mcp_protocol.py
+++ b/tests/unit/test_mcp_protocol.py
@@ -1,11 +1,12 @@
 """Unit tests for MCP protocol encoding/decoding."""
 
 import json
+
 import pytest
 
 from sts2_autotest.cli.mcp_protocol import (
-    McpResponse,
     McpError,
+    McpResponse,
     McpTool,
     decode_request,
     encode_response,

--- a/tests/unit/test_mcp_server.py
+++ b/tests/unit/test_mcp_server.py
@@ -3,7 +3,6 @@
 import json
 import os
 
-
 from sts2_autotest.cli.mcp_protocol import MCP_PROTOCOL_VERSION
 from sts2_autotest.cli.mcp_server import McpServer
 

--- a/tests/unit/test_mcp_tools.py
+++ b/tests/unit/test_mcp_tools.py
@@ -1,21 +1,21 @@
 """Unit tests for MCP tool implementations."""
 
 import sys
-from unittest.mock import MagicMock, patch
 from pathlib import Path
+from unittest.mock import MagicMock, patch
 
 import pytest
 
 from sts2_autotest.cli.mcp_protocol import McpError
 from sts2_autotest.cli.mcp_tools import (
     ToolRegistry,
-    handle_health_check,
-    handle_review_spec,
     handle_compile_spec,
-    handle_run_test,
     handle_get_report,
+    handle_health_check,
     handle_list_specs,
+    handle_review_spec,
     handle_run_pipeline,
+    handle_run_test,
     run_tests_in_dir,
 )
 
@@ -535,7 +535,11 @@ class TestReviewSpec:
     @patch("sts2_autotest.cli.mcp_tools._validate_path")
     @patch("sts2_autotest.cli.mcp_tools.review_spec_file")
     def test_review_spec_calls_reviewer(self, mock_review, mock_validate, tmp_path):
-        from sts2_autotest.common.spec_models import ReviewReport, ReviewIssue, IssueCategory
+        from sts2_autotest.common.spec_models import (
+            IssueCategory,
+            ReviewIssue,
+            ReviewReport,
+        )
         spec_file = tmp_path / "TC-TEST.md"
         spec_file.write_text("# Test")
         mock_validate.return_value = spec_file

--- a/tests/unit/test_metrics.py
+++ b/tests/unit/test_metrics.py
@@ -6,9 +6,7 @@ import json
 from pathlib import Path
 from unittest.mock import patch
 
-
 from sts2_autotest.evidence.metrics import MetricEvent, MetricsCollector
-
 
 # ── MetricEvent ─────────────────────────────────────────────
 

--- a/tests/unit/test_navigation_flow.py
+++ b/tests/unit/test_navigation_flow.py
@@ -1,5 +1,4 @@
-from sts2_autotest.core.navigation import choose_progress_action
-from sts2_autotest.core.navigation import progress_until
+from sts2_autotest.core.navigation import choose_progress_action, progress_until
 
 
 def test_choose_progress_action_discards_potion_on_post_combat_map() -> None:
@@ -109,8 +108,10 @@ def test_progress_until_falls_back_to_grid_select_card_when_skip_rejected() -> N
 def test_progress_until_raises_when_skip_rejected_and_no_card_selectable() -> None:
     """跳过被拒且无可选卡牌时，仍应如实 ACTION_FAILED（不允许静默假通过）。"""
     import asyncio
-    import pytest
     from types import SimpleNamespace
+
+    import pytest
+
     from sts2_autotest.core.navigation import NavigationBlocked
 
     event_state = {

--- a/tests/unit/test_notifier.py
+++ b/tests/unit/test_notifier.py
@@ -2,7 +2,6 @@
 
 from unittest import mock
 
-
 from sts2_autotest.common.types import DesktopNotifier
 
 
@@ -117,6 +116,7 @@ class TestMacOSNotifier:
     def test_notify_handles_timeout(self) -> None:
         """notify should handle subprocess timeout gracefully."""
         import subprocess as sp
+
         from sts2_autotest.core.notifier import MacOSNotifier
 
         notifier = MacOSNotifier()

--- a/tests/unit/test_packager.py
+++ b/tests/unit/test_packager.py
@@ -11,9 +11,8 @@ from unittest.mock import patch
 import pytest
 
 from sts2_autotest import __version__
-from sts2_autotest.common.evidence import FailureInfo, SCHEMA_VERSION
+from sts2_autotest.common.evidence import SCHEMA_VERSION, FailureInfo
 from sts2_autotest.evidence.packager import EvidencePackager
-
 
 # ── create_pack ─────────────────────────────────────────────
 

--- a/tests/unit/test_pipeline_evidence.py
+++ b/tests/unit/test_pipeline_evidence.py
@@ -13,7 +13,6 @@ from pathlib import Path
 
 import pytest
 
-
 _SCRIPT = Path(__file__).resolve().parents[2] / "scripts/pipeline_evidence.py"
 _SPEC = importlib.util.spec_from_file_location("pipeline_evidence_script", _SCRIPT)
 assert _SPEC is not None and _SPEC.loader is not None

--- a/tests/unit/test_plugin.py
+++ b/tests/unit/test_plugin.py
@@ -1,10 +1,9 @@
 """Tests for pytest_plugin/plugin.py — hook integration and notification callback."""
 
-import os
 import json
+import os
 from pathlib import Path
 from unittest import mock
-
 
 
 class TestPytestSessionfinish:

--- a/tests/unit/test_project_extension.py
+++ b/tests/unit/test_project_extension.py
@@ -235,6 +235,7 @@ class TestPerTaskProjectResolution:
     def test_compile_cmd_passes_project_aliases(self, tmp_path, monkeypatch) -> None:
         """从公共服务目录编译项目规格时，角色别名随 project 生效。"""
         from argparse import Namespace
+
         from sts2_autotest.cli import main as cli_main
 
         mod_dir = self._make_mod_project(tmp_path / "my-mod")
@@ -278,6 +279,7 @@ class TestPerTaskProjectResolution:
     def test_project_directory_determines_spec_and_output_dirs(self, tmp_path, monkeypatch) -> None:
         """目录型项目同时决定规格来源与默认输出，不回退平台默认目录。"""
         from argparse import Namespace
+
         from sts2_autotest.cli.main import _resolve_output_dir, _resolve_spec_dir
 
         monkeypatch.chdir(tmp_path)  # 公共服务目录：无 docs/process/specs
@@ -307,8 +309,10 @@ class TestPerTaskProjectResolution:
 
     def test_explicit_project_without_declarations_fails_structurally(self, tmp_path, monkeypatch) -> None:
         """显式项目缺少规格/输出声明时结构化失败，绝不回退平台目录。"""
-        import pytest
         from argparse import Namespace
+
+        import pytest
+
         from sts2_autotest.cli.main import (
             ProjectConfigError,
             _resolve_output_dir,
@@ -332,8 +336,10 @@ class TestPerTaskProjectResolution:
 
     def test_explicit_project_with_nonexistent_spec_dir_fails(self, tmp_path, monkeypatch) -> None:
         """项目声明的规格目录不存在时结构化失败（无效目录检查）。"""
-        import pytest
         from argparse import Namespace
+
+        import pytest
+
         from sts2_autotest.cli.main import ProjectConfigError, _resolve_spec_dir
 
         monkeypatch.chdir(tmp_path)

--- a/tests/unit/test_recovery_strategy.py
+++ b/tests/unit/test_recovery_strategy.py
@@ -8,6 +8,7 @@ import pytest
 
 from sts2_autotest.adapters.base import HealthStatus
 from sts2_autotest.common.errors import ErrorCategory, STS2Error
+from sts2_autotest.core.popup_disposal import PopupDisposition
 from sts2_autotest.core.recovery import (
     DefaultRecoveryStrategy,
     FailureRecord,
@@ -16,8 +17,6 @@ from sts2_autotest.core.recovery import (
     crash_signature,
     is_p0_exception,
 )
-from sts2_autotest.core.popup_disposal import PopupDisposition
-
 
 # ── RecoveryAction enum ────────────────────────────────────
 

--- a/tests/unit/test_repair_advisor.py
+++ b/tests/unit/test_repair_advisor.py
@@ -2,21 +2,19 @@
 
 from __future__ import annotations
 
-
 from sts2_autotest.common.evidence import (
+    EnvironmentInfo,
     FailureInfo,
     RepairSuggestion,
-    SummaryJson,
     RunInfo,
-    EnvironmentInfo,
+    SummaryJson,
 )
 from sts2_autotest.core.repair_advisor import (
     RepairAdvisor,
+    _enrich_with_stack_locations,
     _match_rules,
     _parse_stack_trace,
-    _enrich_with_stack_locations,
 )
-
 
 # ── L1 Rule Engine ────────────────────────────────────────────
 

--- a/tests/unit/test_report_html.py
+++ b/tests/unit/test_report_html.py
@@ -9,7 +9,6 @@ from pathlib import Path
 
 from sts2_autotest.report_html import _b64img, build_report_html, write_html_report
 
-
 _PNG_1X1 = base64.b64decode(
     "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAusB9WlH0wAAAABJRU5ErkJggg=="
 )

--- a/tests/unit/test_smoke_card_validation.py
+++ b/tests/unit/test_smoke_card_validation.py
@@ -2,11 +2,11 @@
 
 from __future__ import annotations
 
-from pathlib import Path
-from unittest.mock import AsyncMock, MagicMock, patch
 import os
 import subprocess
 import sys
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
@@ -15,9 +15,9 @@ from sts2_autotest.common.state import GameScreen, GameState
 from sts2_autotest.core.test_agent_runner import (
     CheckResult,
     TestAgentRunner,
+    _capture_macos_window_png,
     _find_build_output,
     _find_godot_path,
-    _capture_macos_window_png,
     _launch_game_via_desktop_open,
     _start_steam_client_without_polling,
 )

--- a/tests/unit/test_spec_models.py
+++ b/tests/unit/test_spec_models.py
@@ -2,7 +2,13 @@
 from __future__ import annotations
 
 from sts2_autotest.common.spec_models import (
-    TestSpec, SuiteSpec, ReviewReport, ReviewIssue, IssueCategory, ProjectConfig, WorkspaceConfig,
+    IssueCategory,
+    ProjectConfig,
+    ReviewIssue,
+    ReviewReport,
+    SuiteSpec,
+    TestSpec,
+    WorkspaceConfig,
 )
 
 

--- a/tests/unit/test_spec_reviewer.py
+++ b/tests/unit/test_spec_reviewer.py
@@ -1,7 +1,9 @@
 """Tests for spec_reviewer.py — ReviewReport + RevisedDraft generation."""
 from sts2_autotest.common.spec_models import (
-    TestSpec, SuiteSpec, RevisedDraft,
     IssueCategory,
+    RevisedDraft,
+    SuiteSpec,
+    TestSpec,
 )
 from sts2_autotest.core.spec_reviewer import SpecReviewer
 

--- a/tests/unit/test_steam.py
+++ b/tests/unit/test_steam.py
@@ -7,7 +7,7 @@ from unittest.mock import MagicMock, patch
 import psutil
 import pytest
 
-from sts2_autotest.core.steam import SteamController, _GAME_EXE, _IS_MACOS
+from sts2_autotest.core.steam import _GAME_EXE, _IS_MACOS, SteamController
 
 
 @pytest.fixture

--- a/tests/unit/test_watchdog.py
+++ b/tests/unit/test_watchdog.py
@@ -177,7 +177,11 @@ class TestTerminateSession:
 
     def test_timing_budget_constraint(self) -> None:
         """Prove _MAX_DETECTION_INTERVAL + _TERM_GRACE + _KILL_WAIT ≤ 35s."""
-        from sts2_autotest.core.watchdog import _TERM_GRACE, _KILL_WAIT, _MAX_DETECTION_INTERVAL
+        from sts2_autotest.core.watchdog import (
+            _KILL_WAIT,
+            _MAX_DETECTION_INTERVAL,
+            _TERM_GRACE,
+        )
         worst_case_total = _MAX_DETECTION_INTERVAL + _TERM_GRACE + _KILL_WAIT
         assert worst_case_total <= 35.0, (
             f"Budget exceeded: {_MAX_DETECTION_INTERVAL}s + {_TERM_GRACE}s + "
@@ -202,7 +206,11 @@ class TestTerminateSession:
 
     def test_monitoring_interval_respects_budget(self) -> None:
         """Verify monitor interval formula ensures detection + termination ≤ 35s."""
-        from sts2_autotest.core.watchdog import _MAX_DETECTION_INTERVAL, _TERM_GRACE, _KILL_WAIT
+        from sts2_autotest.core.watchdog import (
+            _KILL_WAIT,
+            _MAX_DETECTION_INTERVAL,
+            _TERM_GRACE,
+        )
         # Worst case: longest detection interval + both waits
         worst_case = _MAX_DETECTION_INTERVAL + _TERM_GRACE + _KILL_WAIT
         assert worst_case <= 35.0, f"Budget exceeded: {worst_case}s > 35s"

--- a/tests/unit/test_workspace.py
+++ b/tests/unit/test_workspace.py
@@ -1,9 +1,11 @@
 """Tests for workspace.py — MOD project discovery."""
 from __future__ import annotations
 
+from pathlib import Path
+
 import pytest
 import yaml
-from pathlib import Path
+
 from sts2_autotest.core.workspace import Workspace, WorkspaceError
 
 


### PR DESCRIPTION
## 目标
启动 Ruff 历史质量债的分批治理。第一批只处理机械性、低风险、原则上不改变运行行为的问题。

## 第一批实际范围
- `I001`：import 排序。
- `RUF022`：`__all__` 排序。
- `F541`：移除无占位符的 f-string。
- `UP035`：仅修复 `core/lifecycle.py` 中 1 个因 import 重排暴露出的既有 `Callable` 导入问题。
- 保留 `.github/scripts/check_ruff_baseline.py` 的规则分布输出，后续每批都能直接看到剩余债务结构。
- 未批量处理 `RUF100`：验证发现单独自动修复它会错误删除仍用于压制其他历史规则的 `noqa`，因此已撤回。

## Ruff 结果（Run #31）
- 历史基线：473
- 当前：357
- 本批解决：116
- 新增：0
- 降幅：24.5%

当前最大剩余项：
- `BLE001` 127
- `SIM117` 44
- `UP017` 34
- `S110` 33
- `PLR0402` 17
- `PLW1510` 13
- `UP035` 12
- `UP037` 11

## 风险控制
- 没有采用全量 `ruff --fix`。
- 第一轮曾验证 `RUF100` 会产生 15 个新 Ruff finding，已完整撤回，没有进入最终分支。
- 临时用于自动生成机械修复的 GitHub Actions Job 已删除，最终 workflow 与 main 保持一致。
- `BLE001`、`S110`、`SIM117` 等异常处理/控制流规则留给后续独立批次，不在本批混改。

## 验收（Run #31）
- [x] Ruff 历史债从 473 明确下降到 357。
- [x] 新增 Ruff 债务 = 0。
- [x] Ruff macOS / Ubuntu / Windows 全部通过。
- [x] mypy / import-layer macOS / Ubuntu / Windows 全部通过。
- [x] unit tests macOS / Ubuntu / Windows 全部没有新增失败。
- [x] self-hosted Mac 找到真实 STS2 CLI，CLI integration tests 实际执行并通过。

第一批已满足合并门槛。后续高风险异常处理/控制流债务不在本 PR 扩大范围。