### PR TITLE
T3b 失败样例探针：CI 必失败的 PR（issue-23 验证用，勿合并）

### DIFF
--- a/tests/unit/test_t3_probe_ci_failure.py
+++ b/tests/unit/test_t3_probe_ci_failure.py
@@ -1,0 +1,9 @@
+"""T3b 失败样例探针（issue-23）：刻意构造 CI 失败以验证合并门禁。
+
+该文件仅存在于探针分支，验证结束后随分支删除，不会进入 main。
+"""
+
+
+def test_t3_probe_ci_failure() -> None:
+    """刻意失败的测试：用于验证 PR Check Summary 失败时合并入口被禁用。"""
+    assert False, "T3b 探针：故意失败"


### PR DESCRIPTION
## T3b 失败样例（issue-23）

- 用途：验证「PR Check Summary 失败时合并入口被禁用」的规则生效
- 内容：新增一个刻意失败的单元测试（仅本分支存在，验证后删除）
- **请勿合并此 PR**：这是失败样例验证探针

🤖 Generated with [Claude Code](https://claude.com/claude-code)