### PR TITLE
docs: issue-23 T5 收尾——成功样例证据与状态终版

### DIFF
--- a/.agent-runs/issue-23-main-merge-protection/STATE.md
+++ b/.agent-runs/issue-23-main-merge-protection/STATE.md
@@ -1,8 +1,8 @@
 # STATE — issue-23-main-merge-protection
 
-- 更新时间：2026-08-14（开发阶段，T4 合并进行中）
-- 阶段：开发完成（T0–T3 已验证，T4 成功样例 PR 提交中，T5 回填待办）
-- 状态机位置：`DEV_ASSIGNED` → `DEV_REVIEW`（T4 合并后由 Review 节点接续）
+- 更新时间：2026-08-14（开发阶段全部完成，T5 回填收尾）
+- 阶段：开发完成（T0–T4 全部验证通过），进入 Review
+- 状态机位置：`DEV_ASSIGNED` → `DEV_REVIEW`（Review 节点从 stage-handoff-s2.md 读起）
 
 ## 当前事实（均已落盘，不依赖会话记忆）
 
@@ -11,11 +11,12 @@
 - **main 分支保护已生效**（回读证据 `evidence/t1-protection-readback.json`）：
   - 必填检查 `PR Check Summary`，strict=true，enforce_admins=true，无审批要求，禁 force push/删除。
 - **ruleset「Autotest protect」已修正**（`evidence/t1-ruleset-readback.json`）：
-  - 审批数 1→0（solo 维护者决策）；必填检查 `Unit Tests`→`PR Check Summary`（修复 2026-07-29 旧 job 名悬空）；无绕过者（bypass=never）。
-- **失败样例已验证**：
-  - T3a 直接 push main → GH013 拒绝（`evidence/t3a-direct-push-rejected.md`）。
-  - T3b 失败 CI 的 PR（#26）→ 合并 405 拒绝 + BLOCKED（`evidence/t3b-check-failure-merge-blocked.md`，失败 run https://github.com/crystepj-max/STS2-AUTOTEST/actions/runs/31768184810）；探针已清理。
-- **成功样例进行中**：T4 文档 PR（治理文档 + 证据归档）通过 PR Check Summary 后合并。
+  - 审批数 1→0；必填检查 `Unit Tests`→`PR Check Summary`（修复旧 job 名悬空）；无绕过者（bypass=never）。
+- **失败样例已验证**（`evidence/t3a-direct-push-rejected.md`、`t3b-check-failure-merge-blocked.md`）：
+  - T3a 直接 push main → GH013 拒绝；
+  - T3b 失败 CI 的 PR（#26）→ 合并 405 拒绝 + BLOCKED（失败 run 31768184810）。
+- **成功样例已验证**（`evidence/t4-success-sample.md`）：
+  - 治理文档 PR #27 → PR Check Summary success（run 31768914035，重跑后全绿）→ 已合并（a0673525）。
 - 治理文档：`docs/process/main-merge-protection.md`（规则现状、常规流程、紧急绕过、双向证据、完成标准对照）。
 
 ## 风险与注意
@@ -25,9 +26,9 @@
 - **md-only PR 无法合并**：paths-ignore 忽略 docs/**.md，纯文档 PR 无 PR Check Summary；文档更新须附带非忽略文件（治理文档已写明）。
 - issue-13（PR #22）未合并，main push 检查（ci-main.yml lint）仍失败，与本任务正交，不阻塞本任务门禁。
 - 本任务未改动 `src/`、`tests/` 与 `.github/workflows/`（Issue 明确不做项）。
+- 自托管 runner 网络偶发中断（T4 首次运行 ECONNRESET），重跑即可恢复——已有先例记录。
 
 ## 下一步
 
-1. T4 成功样例 PR 合并（本 PR）。
-2. T5：回填 Issue 完成标准（勾选 + 证据链接 + 关闭）、补 `ready`/`done` 标签、更新本文件终版。
-3. Review 节点接续（读 stage-handoff-s2.md）。
+1. Review 节点接续：读 `stage-handoff-s2.md` 与 `developer-handoff.md`，核对配置回读与双向证据。
+2. Review 通过后关闭 Issue #23（完成标准已全部勾选，证据链完整）。

--- a/.agent-runs/issue-23-main-merge-protection/developer-handoff.md
+++ b/.agent-runs/issue-23-main-merge-protection/developer-handoff.md
@@ -12,7 +12,7 @@
 - **T1**：配置 main 分支保护（必填 `PR Check Summary`、strict=true、enforce_admins=true、无审批要求、禁 force push/删除），并修正既有 ruleset「Autotest protect」的悬空配置（旧检查名 `Unit Tests` 已不存在于重构后的 ci-pr.yml；审批数 1→0 对齐用户决策）。修正后 ruleset 与 branch protection 一致，无绕过者。
 - **T2**：治理文档 `docs/process/main-merge-protection.md`（规则现状、常规流程、紧急绕过流程、双向验证证据、完成标准对照）。
 - **T3**：失败样例双向验证——(a) 直接 push main 被远端拒绝（GH013）；(b) 构造 CI 必失败的 PR，PR Check Summary 失败后合并被 HTTP 405 拒绝、状态 BLOCKED。
-- **T4**：本 PR（治理文档 + 证据归档）作为成功样例，通过 PR Check Summary 后正常合并（进行中）。
+- **T4**：本 PR（治理文档 + 证据归档）作为成功样例，PR Check Summary 通过（run 31768914035）后正常合并（合并提交 a0673525）。
 
 ## 修改文件
 
@@ -54,7 +54,7 @@ python -m pytest tests/unit/ -q        # NOT_RUN：本次无代码改动，PR CI
 - 保护配置回读：**PASSED**（`t1-protection-readback.json`、`t1-ruleset-readback.json`）
 - T3a 失败样例：**PASSED**（直接 push main 被拒，`t3a-direct-push-rejected.md`）
 - T3b 失败样例：**PASSED**（失败 CI 的 PR 合并被 405 拒绝 + BLOCKED，`t3b-check-failure-merge-blocked.md`）
-- T4 成功样例：**进行中**（本 PR 的 PR Check Summary 通过后合并）
+- T4 成功样例：**PASSED**（PR #27，run 31768914035 success，合并提交 a0673525）
 - 单元测试 / mypy / lint-imports：**NOT_RUN**（本次零代码改动；PR CI 会全量执行，以 PR Check Summary 为准）
 - Localization：**NOT_APPLICABLE**
 - Smoke Test：**NOT_APPLICABLE**（无游戏内变更）

--- a/.agent-runs/issue-23-main-merge-protection/evidence/t4-success-sample.md
+++ b/.agent-runs/issue-23-main-merge-protection/evidence/t4-success-sample.md
@@ -1,0 +1,24 @@
+# T4 成功样例证据：满足规则的 PR 正常合并（2026-08-14）
+
+## 样例 PR
+
+- PR: https://github.com/crystepj-max/STS2-AUTOTEST/pull/27（治理文档 + 证据归档）
+- 内容：`docs/process/main-merge-protection.md` + `.agent-runs/issue-23-main-merge-protection/`（task.yaml、STATE、stage-handoff、developer-handoff、evidence/）
+- 附带非忽略文件（证据 JSON/txt）→ 正常触发 ci-pr.yml
+
+## CI 结果
+
+- PR Check Summary: **success**
+- 成功 run: https://github.com/crystepj-max/STS2-AUTOTEST/actions/runs/31768914035
+- 说明：首次运行因自托管 runner 网络中断（ECONNRESET，artifact 上传与 visual 依赖安装失败）失败，与 PR 内容无关；重跑后全绿。
+
+## 合并记录
+
+- 合并时间：2026-08-14T04:31:43Z
+- 合并提交：`a0673525aa32fe3845efdbea47c3b023dd442856`
+- 合并方式：PR 形态 + `PR Check Summary` 成功（strict=true，分支与 main 最新）
+
+## 结论
+
+满足规则（PR 形态 + 最终提交通过 PR Check Summary）的 PR 可以正常合并，
+符合 Issue 完成标准第四条。

--- a/.agent-runs/issue-23-main-merge-protection/evidence/t5-final-evidence.json
+++ b/.agent-runs/issue-23-main-merge-protection/evidence/t5-final-evidence.json
@@ -1,0 +1,34 @@
+{
+  "task_id": "issue-23-main-merge-protection",
+  "updated_at": "2026-08-14",
+  "phase": "T5 收尾（T0-T4 已完成）",
+  "repo_visibility": "PUBLIC",
+  "branch_protection": {
+    "required_status_checks": ["PR Check Summary"],
+    "strict": true,
+    "enforce_admins": true,
+    "required_approving_review_count": 0
+  },
+  "ruleset": {
+    "name": "Autotest protect",
+    "required_status_checks": ["PR Check Summary"],
+    "bypass_actors": [],
+    "current_user_can_bypass": "never"
+  },
+  "verification": {
+    "t3a_direct_push_rejected": true,
+    "t3b_failed_ci_merge_blocked": true,
+    "t3b_failed_run": 31768184810,
+    "t4_success_pr": 27,
+    "t4_success_run": 31768914035,
+    "t4_merge_commit": "a0673525aa32fe3845efdbea47c3b023dd442856"
+  },
+  "acceptance": {
+    "fail_or_missing_check_blocks_merge": true,
+    "strict_final_commit": true,
+    "direct_main_push_blocked": true,
+    "success_pr_mergeable": true,
+    "emergency_bypass_defined": true,
+    "docs_committed": true
+  }
+}

--- a/.agent-runs/issue-23-main-merge-protection/stage-handoff-s2.md
+++ b/.agent-runs/issue-23-main-merge-protection/stage-handoff-s2.md
@@ -21,7 +21,7 @@
 | T1 | 分支保护 + ruleset 修正 | ✅ | `evidence/t1-protection-readback.json`、`t1-ruleset-readback.json` |
 | T2 | 治理文档 | ✅ | `docs/process/main-merge-protection.md` |
 | T3 | 失败样例（push 被拒 + 失败 CI 合并被禁） | ✅ | `evidence/t3a-*`、`t3b-*` |
-| T4 | 成功样例（本 PR 合并） | 进行中 | 本 PR 合并记录 |
+| T4 | 成功样例（本 PR 合并） | ✅ | PR #27，run 31768914035，合并 a0673525 |
 | T5 | Issue 回填 + 收尾 | 待办 | — |
 
 ## Review 重点

--- a/docs/process/main-merge-protection.md
+++ b/docs/process/main-merge-protection.md
@@ -76,8 +76,11 @@
 
 ### 成功样例
 
-- 本 PR（治理文档 + 证据归档）通过 `PR Check Summary` 后正常合并 → 证明「满足规则的 PR 可以正常合并」。
-  - 合并提交与成功 run 链接见本 PR 合并记录。
+- 治理文档 PR 通过 `PR Check Summary` 后正常合并 → 证明「满足规则的 PR 可以正常合并」：
+  - PR: https://github.com/crystepj-max/STS2-AUTOTEST/pull/27
+  - 成功 run: https://github.com/crystepj-max/STS2-AUTOTEST/actions/runs/31768914035
+  - 合并提交: `a0673525aa32fe3845efdbea47c3b023dd442856`（2026-08-14）
+  - 证据：[`t4-success-sample.md`](../../.agent-runs/issue-23-main-merge-protection/evidence/t4-success-sample.md)
 
 ## 与 Issue 完成标准对照
 


### PR DESCRIPTION
## issue-23 T5 收尾

- 治理文档补充成功样例链接（PR #27 / run 31768914035 / 合并提交 a0673525）
- 新增 `evidence/t4-success-sample.md`（T4 合并证据，同时触发本 PR 的 CI）
- STATE.md 终版：T0–T4 全部完成，进入 Review
- developer-handoff / stage-handoff-s2 同步 T4 完成状态

本 PR 附带非忽略文件（`.md` 会被 paths-ignore）→ 正常触发 `PR Check Summary`。

🤖 Generated with [Claude Code](https://claude.com/claude-code)