### PR TITLE
chore: 将 .workbuddy 与 .serena 加入 .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -105,3 +105,7 @@ sts2-autotest.yml
 
 # CodeGraph 本地索引（代码地图缓存，不入库）
 .codegraph/
+
+# 本地 agent 记忆与配置（不随平台分发）
+.workbuddy/
+.serena/


### PR DESCRIPTION
## 目的
将机器相关的本地 agent 产物排除在版本控制之外，避免其随平台分发或被误提交。

## 改动内容
在 `.gitignore` 末尾追加两条忽略规则：
- `.workbuddy/` —— 本地 agent 记忆与配置目录（机器相关，含 per-project memory）
- `.serena/` —— serena 本地配置目录

## 背景
此前在执行 `git stash -u` 同步 main 时，`.workbuddy/` 作为未跟踪目录被一并收进 stash，险些造成项目记忆丢失。将其明确忽略后，可避免后续 `stash` / `pull` / `add` 反复误收或误提交。

## 影响范围
- 仅修改 `.gitignore`，不涉及任何平台代码、测试或配置逻辑。
- 已忽略目录中的既有文件不会被删除（本机 `.workbuddy/` 仍保留在工作区，仅从版本追踪中移除）。

## 验证
- 本地工作区 `git status` 不再显示 `.workbuddy/` / `.serena/`。
- 本提交仅含 `.gitignore` 4 行新增，无其他文件改动。

⚠️ 按项目红线（main 合并前需经 PR + 最终自动验收），本 PR 待 `PR Check Summary` 通过后由负责人 review 合入，未授权自动合入。