### PR TITLE
perf(issue-37): CliMod 适配器降频去重 + 失败签名短路减少可避免重启

### DIFF
--- a/docs/user-manual.md
+++ b/docs/user-manual.md
@@ -182,7 +182,7 @@ execution:
 
 state_machine:
   transition_timeout: 10.0
-  poll_interval: 0.5
+  poll_interval: 1.0
 ```
 
 ### 5.2 常用配置项
@@ -199,7 +199,7 @@ state_machine:
 | `execution.game_timeout` | `60.0` | 游戏动作等待超时。 |
 | `execution.max_retries` | `3` | 默认重试次数。 |
 | `execution.max_consecutive_failures` | `3` | 连续相同失败达到阈值后标记为确定性失败。 |
-| `state_machine.poll_interval` | `0.5` | 状态轮询间隔。 |
+| `state_machine.poll_interval` | `1.0` | 状态轮询间隔。 |
 
 ## 6. 命令行使用
 

--- a/src/sts2_autotest/adapters/cli_mod.py
+++ b/src/sts2_autotest/adapters/cli_mod.py
@@ -81,8 +81,13 @@ class CliModAdapter:
         cli_path: str | None = None,
         timeout: float = 30.0,
         version_output: str | None = None,
+        poll_interval: float = 0.5,
     ) -> None:
         self.timeout = timeout
+        self.poll_interval = float(poll_interval)
+        # 阶段 A（issue #37）：_run_cli 入口埋点——每次工具启动（含失败）都计数，
+        # 供性能对比「同场战斗启动次数 ↓≥50%」验收度量。
+        self.cli_launch_count = 0
         self._cache_stale = True
         self._cached_state: GameState | None = None
         self._version_checked = False
@@ -112,6 +117,8 @@ class CliModAdapter:
         non-zero exit code, or JSON parse failure.
         """
         cmd = [self.cli_path, *args]
+        # 埋点：统计口径为「实际工具启动次数」，失败调用同样计入（置于 Popen 之前）。
+        self.cli_launch_count += 1
         try:
             proc = subprocess.Popen(
                 cmd,
@@ -585,6 +592,10 @@ class CliModAdapter:
         deadline = time.monotonic() + min(self.timeout, 60.0)
         steps = 0
         consecutive_play_failures = 0
+        # 阶段 A（issue #37）：等待期自适应降频——非玩家回合（状态未变）时轮询
+        # 间隔逐轮翻倍、封顶 2×poll_interval，不再逐轮满频查询；玩家回合（状态
+        # 变化）复位基础间隔。等待期每轮仍读取一次状态（保行为一致）。
+        wait_interval = self.poll_interval
         try:
             while time.monotonic() < deadline and steps < 80:
                 self._cache_stale = True
@@ -598,8 +609,12 @@ class CliModAdapter:
                     return ActionResult(status="failure", state_changed=False, detail="Combat payload missing")
 
                 if not combat.get("is_player_turn", False) or combat.get("is_player_actions_disabled", False):
-                    time.sleep(0.5)
+                    time.sleep(wait_interval)
+                    wait_interval = min(wait_interval * 2.0, self.poll_interval * 2.0)
                     continue
+
+                # 状态已变化（玩家回合）→ 复位等待退避。
+                wait_interval = self.poll_interval
 
                 play_args = _choose_basic_combat_card(combat)
                 if play_args is not None:

--- a/src/sts2_autotest/cli/main.py
+++ b/src/sts2_autotest/cli/main.py
@@ -2142,6 +2142,56 @@ def _run_environment_precheck(adapter: GameAdapterProtocol) -> str | None:
     return reason_str or "ENVIRONMENT_NOT_READY"
 
 
+def _build_cancel_result(
+    *,
+    duration_ms: int,
+    trajectory: list[Any],
+    pre_cancel_state: Any,
+    recovered_state: Any,
+    last_action: Any,
+    journey_evidence: dict[str, Any],
+    evidence_dir: str | None,
+    recovery: dict[str, Any],
+    lifecycle: Any,
+) -> dict[str, Any]:
+    """构造取消收尾报告数据（run-result.json 的 extra 部分）。
+
+    阶段 C 复审 B1（issue #37）：restart_count 提升到报告顶层，与 relaunch_count
+    同口径——仅当受控重启恢复路径真实执行过（lifecycle 可用）才暴露 recovery 中
+    的真实计数；lifecycle 不可用（无恢复数据源）不写该 key，禁止编造 0。
+    recovery 子 dict 原样保留，供审计核对恢复结果细节。
+    """
+    result: dict[str, Any] = {
+        "duration_ms": duration_ms,
+        "status_trajectory": trajectory,
+        "pre_cancel_state": pre_cancel_state,
+        "pre_cancel_screen": (pre_cancel_state or {}).get("screen")
+        if isinstance(pre_cancel_state, dict) else None,
+        "recovered_screen": (recovered_state or {}).get("screen")
+        if isinstance(recovered_state, dict) else None,
+        "last_action": last_action,
+        "journey_evidence": journey_evidence,
+        "evidence_dir": evidence_dir,
+        # 受控重启恢复结果标记（如实写，不得伪装 normal_game_menu）。
+        "recovery": {
+            "target": recovery.get("target"),
+            "recovery_method": recovery.get("recovery_method"),
+            "normal_menu_abandon": recovery.get("normal_menu_abandon"),
+            "restart_count": recovery.get("restart_count"),
+            "final_screen": recovery.get("final_screen"),
+            "clean_main_menu": recovery.get("clean_main_menu"),
+            "old_run_abandoned": recovery.get("old_run_abandoned"),
+            "reason": recovery.get("reason"),
+            "final_state": recovery.get("final_state"),
+        },
+    }
+    if lifecycle is not None:
+        count = recovery.get("restart_count")
+        if isinstance(count, int):
+            result["restart_count"] = count
+    return result
+
+
 def _run_journey_foreground(
     adapter: GameAdapterProtocol,
     *,
@@ -2599,30 +2649,17 @@ def _run_journey_foreground(
 
         # 2) 写取消报告 + 落盘证据 + 封存。证据封存失败单独归类。
         sealed = False
-        cancel_result = {
-            "duration_ms": duration_ms,
-            "status_trajectory": trajectory,
-            "pre_cancel_state": pre_cancel_state,
-            "pre_cancel_screen": (pre_cancel_state or {}).get("screen")
-            if isinstance(pre_cancel_state, dict) else None,
-            "recovered_screen": (recovered_state or {}).get("screen")
-            if isinstance(recovered_state, dict) else None,
-            "last_action": last_action,
-            "journey_evidence": journey_evidence,
-            "evidence_dir": str(evidence_root / run_id) if run_id else None,
-            # 受控重启恢复结果标记（如实写，不得伪装 normal_game_menu）。
-            "recovery": {
-                "target": recovery.get("target"),
-                "recovery_method": recovery.get("recovery_method"),
-                "normal_menu_abandon": recovery.get("normal_menu_abandon"),
-                "restart_count": recovery.get("restart_count"),
-                "final_screen": recovery.get("final_screen"),
-                "clean_main_menu": recovery.get("clean_main_menu"),
-                "old_run_abandoned": recovery.get("old_run_abandoned"),
-                "reason": recovery.get("reason"),
-                "final_state": recovery.get("final_state"),
-            },
-        }
+        cancel_result = _build_cancel_result(
+            duration_ms=duration_ms,
+            trajectory=trajectory,
+            pre_cancel_state=pre_cancel_state,
+            recovered_state=recovered_state,
+            last_action=last_action,
+            journey_evidence=journey_evidence,
+            evidence_dir=str(evidence_root / run_id) if run_id else None,
+            recovery=recovery,
+            lifecycle=lifecycle,
+        )
         # V11 复核要点：最终截图必须在恢复收尾（干净确认）之后采集，
         # 与报告中的 final_state 互为独立证据，随证据包一并封存。
         try:
@@ -3330,7 +3367,9 @@ def _report_from_store(evidence_dir: Path, run_id: str, store_run: Path) -> int:
     if isinstance(result, dict):
         for key in ("duration_ms", "status_trajectory", "pre_cancel_state",
                     "pre_cancel_screen", "recovered_screen", "last_action",
-                    "evidence_dir", "reason"):
+                    "evidence_dir", "reason", "restart_count"):
+            # B1（issue #37）：restart_count 由取消收尾真实写入 result 时才拷贝，
+            # 任务记录中无该字段（无真实数据源）→ 不编造 0。
             if key in result:
                 payload[key] = result[key]
     out_dir = evidence_dir / run_id / "reports"

--- a/src/sts2_autotest/cli/main.py
+++ b/src/sts2_autotest/cli/main.py
@@ -2494,6 +2494,10 @@ def _run_journey_foreground(
                 "target_scene": resolved_target,
                 "journey_evidence": journey_evidence,
                 "evidence_dir": str(evidence_root / run_id) if run_id else None,
+                # 阶段 C（issue #37）：重拉计数进报告——真实生产者 lifecycle.relaunch_count。
+                "relaunch_count": (
+                    lifecycle.relaunch_count if lifecycle is not None else 0
+                ),
             },
         )
         evidence.on_session_end({

--- a/src/sts2_autotest/config/schema.py
+++ b/src/sts2_autotest/config/schema.py
@@ -133,7 +133,10 @@ class StateMachineConfig(BaseModel):
     model_config = ConfigDict(frozen=True)
 
     transition_timeout: float = Field(default=10.0, gt=0)
-    poll_interval: float = Field(default=0.5, gt=0)
+    # 阶段 A（issue #37）：状态轮询间隔默认 0.5s → 1.0s（降频）。去重为主、
+    # 轮询间隔为次要调参；适配器内部等待的实时节奏由 CliModAdapter(poll_interval=…)
+    # 控制，此处为状态机轮询的全局默认值。
+    poll_interval: float = Field(default=1.0, gt=0)
 
 
 class NotificationsConfig(BaseModel):

--- a/src/sts2_autotest/core/lifecycle.py
+++ b/src/sts2_autotest/core/lifecycle.py
@@ -138,7 +138,10 @@ class GameLifecycleManager:
         steam_controller: Any = None,
         app_id: str = _DEFAULT_APP_ID,
         hang_threshold: float = 18.0,
-        max_relaunches: int = 15,
+        # 阶段 C（issue #37）：重拉上限 15 → 3。确定性失败反复重拉 15 次全是
+        # 无效重启（每次都是一次完整游戏重启）；上限收敛后仍保留 3 次容错
+        # （瞬态可恢复），调用方可经构造参数覆盖。
+        max_relaunches: int = 3,
         api_timeout: float = 150.0,
         launch_timeout: float = 120.0,
         poll_interval: float = 3.0,

--- a/src/sts2_autotest/core/orchestrator.py
+++ b/src/sts2_autotest/core/orchestrator.py
@@ -25,6 +25,7 @@ from sts2_autotest.core.recovery import (
     RecoveryAction,
     RecoveryStrategy,
     crash_signature,
+    failure_signature,
     is_p0_exception,
 )
 from sts2_autotest.core.state_engine import StateEngine, StateTransitionError
@@ -767,6 +768,7 @@ class TestOrchestrator:
             message=exc.message,
             timestamp=exc.timestamp.isoformat(),
             exit_code=exc.detail.get("exit_code") if exc.detail else None,
+            signature=failure_signature(exc),
         )
 
         # P0 session-level fatal — always crash, never downgrade

--- a/src/sts2_autotest/core/recovery.py
+++ b/src/sts2_autotest/core/recovery.py
@@ -81,7 +81,7 @@ def crash_signature(error: Exception, exit_code: int | None = None) -> str:
     return f"{type_name}:{code}"
 
 
-def _failure_signature(failure: Exception) -> str:
+def failure_signature(failure: Exception) -> str:
     """当前失败的确定性签名：STS2Error 取 detail.exit_code，其余仅用异常类型。
 
     无 exit_code 时退化为 ``Type:none``，仍可匹配同类无码失败。
@@ -216,7 +216,7 @@ class DefaultRecoveryStrategy:
         # Crashes get progressive recovery levels
         if isinstance(failure, STS2Error) and failure.category == ErrorCategory.CRASH_ERROR:
             return self._decide_crash(
-                history, max_consecutive, _failure_signature(failure), same_signature_shortcut
+                history, max_consecutive, failure_signature(failure), same_signature_shortcut
             )
 
         # Timeouts → fast path (with consecutive escalation)

--- a/src/sts2_autotest/core/recovery.py
+++ b/src/sts2_autotest/core/recovery.py
@@ -53,6 +53,9 @@ class FailureRecord:
     message: str
     timestamp: str
     exit_code: int | None = None
+    # 阶段 C（issue #37）：确定性失败签名（crash_signature 产物）。空串 = 旧格式
+    # 记录（无签名），短路判定对其不生效，保持原渐进恢复逻辑。
+    signature: str = ""
 
 
 # P0 exceptions: session-level — framework/environment cannot proceed
@@ -76,6 +79,20 @@ def crash_signature(error: Exception, exit_code: int | None = None) -> str:
     type_name = type(error).__name__
     code = exit_code if exit_code is not None else "none"
     return f"{type_name}:{code}"
+
+
+def _failure_signature(failure: Exception) -> str:
+    """当前失败的确定性签名：STS2Error 取 detail.exit_code，其余仅用异常类型。
+
+    无 exit_code 时退化为 ``Type:none``，仍可匹配同类无码失败。
+    """
+    exit_code: int | None = None
+    if isinstance(failure, STS2Error):
+        detail = failure.detail or {}
+        code = detail.get("exit_code")
+        if isinstance(code, int) and not isinstance(code, bool):
+            exit_code = code
+    return crash_signature(failure, exit_code)
 
 
 def is_p0_exception(exc: Exception) -> bool:
@@ -104,6 +121,7 @@ class RecoveryStrategy(Protocol):
         history: list[FailureRecord],
         *,
         max_consecutive: int = 3,
+        same_signature_shortcut: int = 2,
     ) -> RecoveryDecision: ...
 
     async def execute(
@@ -128,6 +146,7 @@ class StubRecoveryStrategy:
         history: list[FailureRecord],
         *,
         max_consecutive: int = 3,
+        same_signature_shortcut: int = 2,
     ) -> RecoveryDecision:
         return RecoveryDecision(
             action=RecoveryAction.TERMINATE,
@@ -170,12 +189,15 @@ class DefaultRecoveryStrategy:
         history: list[FailureRecord],
         *,
         max_consecutive: int = 3,
+        same_signature_shortcut: int = 2,
     ) -> RecoveryDecision:
         """Decide recovery action based on exception type + failure history.
 
         Decision logic:
         1. P0 exceptions (FileNotFoundError, OSError, VERSION_MISMATCH) → TERMINATE (is_p0=True)
-        2. CRASH_ERROR → progressive levels: GAME_RESTART → FULL_RESTART → TERMINATE
+        2. CRASH_ERROR → progressive levels: GAME_RESTART → FULL_RESTART → TERMINATE，
+           阶段 C 附加「相同失败签名短路」：连续 same_signature_shortcut 次相同
+           签名 → 直接 TERMINATE，不再 GAME_RESTART / FULL_RESTART 空转
         3. Timeout → FAST_PATH (with consecutive escalation)
         4. Other adapter errors → FAST_PATH (with consecutive escalation)
         """
@@ -193,7 +215,9 @@ class DefaultRecoveryStrategy:
 
         # Crashes get progressive recovery levels
         if isinstance(failure, STS2Error) and failure.category == ErrorCategory.CRASH_ERROR:
-            return self._decide_crash(history, max_consecutive)
+            return self._decide_crash(
+                history, max_consecutive, _failure_signature(failure), same_signature_shortcut
+            )
 
         # Timeouts → fast path (with consecutive escalation)
         if isinstance(failure, STS2Error) and failure.category in _FAST_PATH_CATEGORIES:
@@ -262,6 +286,8 @@ class DefaultRecoveryStrategy:
         self,
         history: list[FailureRecord],
         max_consecutive: int,
+        current_signature: str,
+        same_signature_shortcut: int = 2,
     ) -> RecoveryDecision:
         """Three-level progressive crash recovery.
 
@@ -270,9 +296,18 @@ class DefaultRecoveryStrategy:
         3rd+ consecutive crash → TERMINATE.
         Note: history does NOT include the current crash
         (appended after decide()), so we add +1 for the current.
+
+        阶段 C（issue #37）：相同失败签名短路——当前失败签名非空且连续
+        same_signature_shortcut 次（含本次）相同 → 直接 TERMINATE（is_p0=False）。
+        这类「确定性失败」重启也不可能修复，短路避免 GAME_RESTART / FULL_RESTART
+        空转；判定仍为失败（不掩盖真实失败）。旧格式记录（signature=""）不短路。
         """
         if not history:
             return RecoveryDecision(action=RecoveryAction.GAME_RESTART)
+        if current_signature:
+            consecutive_sig = self._consecutive_signature_count(history, current_signature) + 1
+            if consecutive_sig >= same_signature_shortcut:
+                return RecoveryDecision(action=RecoveryAction.TERMINATE, is_p0=False)
         # Count consecutive crashes from history, +1 for current crash
         consecutive = self._consecutive_count(history, ErrorCategory.CRASH_ERROR.value) + 1
         if consecutive >= max_consecutive:
@@ -280,6 +315,20 @@ class DefaultRecoveryStrategy:
         if consecutive >= max_consecutive - 1:
             return RecoveryDecision(action=RecoveryAction.FULL_RESTART)
         return RecoveryDecision(action=RecoveryAction.GAME_RESTART)
+
+    @staticmethod
+    def _consecutive_signature_count(history: list[FailureRecord], signature: str) -> int:
+        """Count consecutive failures with the same signature from the end of history.
+
+        无签名（""）的记录不参与匹配——旧格式记录使计数中断。
+        """
+        count = 0
+        for record in reversed(history):
+            if record.signature and record.signature == signature:
+                count += 1
+            else:
+                break
+        return count
 
     @staticmethod
     def _consecutive_count(history: list[FailureRecord], error_type: str) -> int:

--- a/src/sts2_autotest/report_html.py
+++ b/src/sts2_autotest/report_html.py
@@ -236,6 +236,21 @@ def build_report_html(config: dict[str, Any]) -> str:
   <span class="badge badge-pass">通过</span>
 </div><div class="case-body"><pre class="log" style="margin-top:8px">{_h(nav_path)}</pre></div></div>"""
 
+    # 阶段 C（issue #37）：重启/重拉计数暴露——哪个 key 提供就渲染哪张卡
+    # （0 也显示）；未提供的 key 不渲染，避免为不存在的计数编造 0，也不破坏
+    # 既有报告格式。
+    counter_cards = ""
+    if "restart_count" in config:
+        counter_cards += (
+            f'\n  <div class="summary-card total"><div class="num">'
+            f'{int(config["restart_count"])}</div>重启次数</div>'
+        )
+    if "relaunch_count" in config:
+        counter_cards += (
+            f'\n  <div class="summary-card total"><div class="num">'
+            f'{int(config["relaunch_count"])}</div>重拉次数</div>'
+        )
+
     return f"""<!DOCTYPE html>
 <html lang="zh-CN">
 <head>
@@ -302,6 +317,7 @@ pre.log{{background:#050510;color:#6ee;padding:8px;border-radius:4px;font-size:1
   <div class="summary-card block"><div class="num">{counts['blocked']}</div>阻塞</div>
   <div class="summary-card skip"><div class="num">{counts['skipped']}</div>跳过</div>
   <div class="summary-card total"><div class="num">{counts['total']}</div>总计</div>
+{counter_cards}
 </div>
 <div style="display:flex;gap:12px;margin-bottom:24px;flex-wrap:wrap">{badge_row}</div>
 <h2 style="font-size:16px;margin-bottom:12px;color:#999">测试案例</h2>

--- a/tests/e2e_crash_recovery.py
+++ b/tests/e2e_crash_recovery.py
@@ -107,13 +107,25 @@ async def test_level3_terminate_after_three_crashes() -> None:
     orch = TestOrchestrator(adapter=_make_adapter(), recovery=strategy)
     assert not orch._crashed
 
-    await orch._handle_failure("TC-001", STS2Error(category=ErrorCategory.CRASH_ERROR, message="crash 1"))
+    # issue #37 引入 same_signature_shortcut=2：连续相同签名会在第 2 次短路为
+    # TERMINATE。为保留「三级渐进恢复」原意，三场崩溃使用不同 exit_code，
+    # 使签名不同、不走短路。
+    await orch._handle_failure(
+        "TC-001",
+        STS2Error(category=ErrorCategory.CRASH_ERROR, message="crash 1", detail={"exit_code": 1}),
+    )
     assert not orch._crashed
 
-    await orch._handle_failure("TC-002", STS2Error(category=ErrorCategory.CRASH_ERROR, message="crash 2"))
+    await orch._handle_failure(
+        "TC-002",
+        STS2Error(category=ErrorCategory.CRASH_ERROR, message="crash 2", detail={"exit_code": 2}),
+    )
     assert not orch._crashed
 
-    r3 = await orch._handle_failure("TC-003", STS2Error(category=ErrorCategory.CRASH_ERROR, message="crash 3"))
+    r3 = await orch._handle_failure(
+        "TC-003",
+        STS2Error(category=ErrorCategory.CRASH_ERROR, message="crash 3", detail={"exit_code": 3}),
+    )
     assert r3.status == "deterministic_fail"
     assert orch._crashed
 

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -584,6 +584,52 @@ class TestReportFromEvidence:
         )
         assert report_cmd(args) == 0
 
+    def test_report_store_synthesis_preserves_restart_count(self, tmp_path: Path) -> None:
+        """B1 契约：detach 合成路径保留真实 restart_count、无数据源不编造。
+
+        取消收尾把 cancel_result（顶层含 restart_count）持久化进 run.json；
+        合成 run-result.json 时必须一并拷贝，否则 detach 任务的报告仍缺重启卡。
+        """
+        store_run = tmp_path / ".runs" / "run-cancelled" / "run.json"
+        store_run.parent.mkdir(parents=True)
+        store_run.write_text(json.dumps({
+            "run_id": "run-cancelled",
+            "status": "CANCELLED",
+            "result": {"restart_count": 1, "recovered_screen": "MAIN_MENU"},
+        }))
+
+        args = _create_parser().parse_args(
+            ["report", "run-cancelled", "--evidence-dir", str(tmp_path)]
+        )
+        assert report_cmd(args) == 0
+        payload = json.loads(
+            (tmp_path / "run-cancelled" / "reports" / "run-result.json").read_text(
+                encoding="utf-8"
+            )
+        )
+        assert payload["restart_count"] == 1
+
+        # 反向：任务记录里没有真实计数 → 合成报告不得编造 0
+        store_run.write_text(json.dumps({
+            "run_id": "run-cancelled-2",
+            "status": "CANCELLED",
+            "result": {"recovered_screen": "MAIN_MENU"},
+        }))
+        (tmp_path / "run-cancelled-2" / "reports").mkdir(parents=True)
+        (tmp_path / "run-cancelled-2" / "reports" / "run-result.json").write_text(
+            json.dumps({"run_id": "run-cancelled-2", "status": "CANCELLED"})
+        )
+        # 用 _report_from_store 直接验证合成逻辑
+        from sts2_autotest.cli.main import _report_from_store
+
+        assert _report_from_store(tmp_path, "run-cancelled-2", store_run) == 0
+        payload2 = json.loads(
+            (tmp_path / "run-cancelled-2" / "reports" / "run-result.json").read_text(
+                encoding="utf-8"
+            )
+        )
+        assert "restart_count" not in payload2
+
 
 class TestCLIEntryPoint:
     """Main CLI function."""

--- a/tests/unit/test_cli_mod_adapter.py
+++ b/tests/unit/test_cli_mod_adapter.py
@@ -712,3 +712,159 @@ class TestMockReplaceability:
         mock = self.MockAdapter()
         adapter_ref: GameAdapterProtocol = mock  # type: ignore[assignment]
         assert adapter_ref is not None
+
+
+# ── 阶段 A：埋点计数 + 轮询间隔配置 + 战斗等待退避（issue #37）──
+
+class _FakeTime:
+    """替身 time 模块：monotonic 递增 + 记录 sleep 调用，避免真实等待。"""
+
+    def __init__(self) -> None:
+        self.now = 0.0
+        self.sleeps: list[float] = []
+
+    def monotonic(self) -> float:
+        return self.now
+
+    def sleep(self, seconds: float) -> None:
+        self.sleeps.append(seconds)
+        self.now += seconds
+
+
+def _combat_payload(is_player_turn: bool, hand: list[dict[str, Any]] | None = None) -> dict[str, Any]:
+    """构造 CLI state 响应的战斗载荷。"""
+    return {
+        "screen": "COMBAT",
+        "combat": {
+            "is_player_turn": is_player_turn,
+            "is_player_actions_disabled": False,
+            "hand": hand or [],
+            "enemies": [],
+        },
+    }
+
+
+class TestCliLaunchCount:
+    """_run_cli 入口埋点计数：每次工具启动（含失败）都计入，供性能对比。"""
+
+    @patch("sts2_autotest.adapters.cli_mod.subprocess.Popen")
+    def test_launch_count_starts_at_zero(
+        self, mock_popen: MagicMock, adapter: CliModAdapter
+    ) -> None:
+        assert adapter.cli_launch_count == 0
+
+    @patch("sts2_autotest.adapters.cli_mod.subprocess.Popen")
+    def test_launch_count_increments_per_cli_call(
+        self, mock_popen: MagicMock, adapter: CliModAdapter
+    ) -> None:
+        mock_popen.return_value = _mock_popen_ok({})
+        _run(adapter.health_check())   # ping → 1 次启动
+        _run(adapter.get_state())      # state → 1 次启动
+        assert adapter.cli_launch_count == 2
+
+    @patch("sts2_autotest.adapters.cli_mod.subprocess.Popen")
+    def test_launch_count_counts_failures_too(
+        self, mock_popen: MagicMock, adapter: CliModAdapter
+    ) -> None:
+        """失败调用同样计数——统计口径为「实际启动次数」，不得漏计。
+
+        用 get_state 而非 health_check：health_check 既有设计吞掉错误返回
+        healthy=False，不传播异常；get_state 会把 CLI 失败作为 STS2Error 抛出。
+        """
+        mock_popen.return_value = _mock_popen_error(returncode=1, stderr="boom")
+        with pytest.raises(STS2Error):
+            _run(adapter.get_state())
+        assert adapter.cli_launch_count == 1
+
+    def test_launch_count_is_per_instance(self) -> None:
+        a = CliModAdapter(cli_path="sts2", timeout=30.0)
+        b = CliModAdapter(cli_path="sts2", timeout=30.0)
+        assert a.cli_launch_count == 0
+        assert b.cli_launch_count == 0
+
+
+class TestPollIntervalConfig:
+    """轮询间隔配置化：默认 0.5s，可经构造参数调整。"""
+
+    def test_default_poll_interval(self) -> None:
+        a = CliModAdapter(cli_path="sts2", timeout=30.0)
+        assert a.poll_interval == 0.5
+
+    def test_custom_poll_interval(self) -> None:
+        a = CliModAdapter(cli_path="sts2", timeout=30.0, poll_interval=1.0)
+        assert a.poll_interval == 1.0
+
+
+class TestCombatWaitBackoff:
+    """阶段 A：战斗等待轮询自适应降频。
+
+    非玩家回合（状态未变）→ 轮询间隔翻倍（0.5 → 1.0 封顶）；
+    玩家回合出现（状态变化）→ 复位基础间隔。等待期间不再逐轮满频查询。
+    """
+
+    def _run_combat_policy(
+        self, poll_interval: float, responses: list[dict[str, Any]]
+    ) -> tuple[Any, _FakeTime, CliModAdapter]:
+        fake_time = _FakeTime()
+        adapter = CliModAdapter(cli_path="sts2", timeout=5.0, poll_interval=poll_interval)
+        mock_proc = MagicMock()
+        mock_proc.communicate.side_effect = [
+            (json.dumps({"ok": True, "data": resp}).encode("utf-8"), b"")
+            for resp in responses
+        ]
+        mock_proc.returncode = 0
+        with patch("sts2_autotest.adapters.cli_mod.subprocess.Popen",
+                   return_value=mock_proc), patch(
+            "sts2_autotest.adapters.cli_mod.time", fake_time
+        ):
+            # _combat_basic_policy_sync 是同步函数，直接调用（不走 asyncio 桥接）。
+            result = adapter._combat_basic_policy_sync()
+        return result, fake_time, adapter
+
+    def test_wait_backoff_doubles_then_caps(self) -> None:
+        """连续等待：0.5 → 1.0 → 1.0（封顶 = 2×poll_interval），不再逐轮满频。"""
+        result, fake_time, adapter = self._run_combat_policy(
+            0.5,
+            [
+                _combat_payload(False),  # 等待 → 0.5
+                _combat_payload(False),  # 等待 → 1.0
+                _combat_payload(False),  # 等待 → 1.0（封顶）
+                {"screen": "VICTORY"},   # 战斗结束
+            ],
+        )
+        assert result.status == "success"
+        assert fake_time.sleeps == [0.5, 1.0, 1.0]
+        # 4 次状态读取（3 次等待 + 1 次战斗结束判定）= 4 次工具启动，
+        # 无等待期间之外的冗余启动。
+        assert adapter.cli_launch_count == 4
+
+    def test_wait_backoff_resets_on_player_turn(self) -> None:
+        """玩家回合出现 → 退避复位；再次等待从基础间隔重新翻倍。"""
+        result, fake_time, adapter = self._run_combat_policy(
+            0.5,
+            [
+                _combat_payload(False),                                  # 等待 → 0.5
+                _combat_payload(False),                                  # 等待 → 1.0
+                _combat_payload(True, hand=[{"id": "1", "type": "Attack", "can_play": True, "target_type": "None"}]),  # 玩家回合 → play_card
+                _combat_payload(False),                                  # play_card 响应（返回后状态仍为等待）
+                _combat_payload(False),                                  # 敌人回合（已复位）→ 0.5
+                {"screen": "VICTORY"},
+            ],
+        )
+        assert result.status == "success"
+        assert fake_time.sleeps == [0.5, 1.0, 0.5]
+        # 5 次状态读取（4 次等待 + 1 次战斗结束判定）+ 1 次 play_card = 6 次启动
+        assert adapter.cli_launch_count == 6
+
+    def test_wait_backoff_uses_configured_poll_interval(self) -> None:
+        """配置 poll_interval=1.0 → 等待基础间隔 1.0、封顶 2.0。"""
+        result, fake_time, adapter = self._run_combat_policy(
+            1.0,
+            [
+                _combat_payload(False),  # 等待 → 1.0
+                _combat_payload(False),  # 等待 → 2.0（封顶）
+                {"screen": "VICTORY"},
+            ],
+        )
+        assert result.status == "success"
+        assert fake_time.sleeps == [1.0, 2.0]

--- a/tests/unit/test_cli_mod_adapter.py
+++ b/tests/unit/test_cli_mod_adapter.py
@@ -858,7 +858,7 @@ class TestCombatWaitBackoff:
 
     def test_wait_backoff_uses_configured_poll_interval(self) -> None:
         """配置 poll_interval=1.0 → 等待基础间隔 1.0、封顶 2.0。"""
-        result, fake_time, adapter = self._run_combat_policy(
+        result, fake_time, _ = self._run_combat_policy(
             1.0,
             [
                 _combat_payload(False),  # 等待 → 1.0

--- a/tests/unit/test_config_loader.py
+++ b/tests/unit/test_config_loader.py
@@ -179,7 +179,7 @@ class TestFullLayerStack:
         assert cfg.execution.game_timeout == 120.0  # from YAML
         assert cfg.framework.log_level == "DEBUG"  # from env
         assert cfg.execution.max_retries == 5  # from CLI
-        assert cfg.state_machine.poll_interval == 0.5  # default
+        assert cfg.state_machine.poll_interval == 1.0  # default
 
     def test_string_project_dir(self, config_dir: Path) -> None:
         cfg = load_config(project_dir=str(config_dir))

--- a/tests/unit/test_config_schema.py
+++ b/tests/unit/test_config_schema.py
@@ -166,7 +166,7 @@ class TestSTS2Config:
         assert cfg.framework.log_level == "INFO"
         assert cfg.adapter.cli.enabled is True
         assert cfg.execution.game_timeout == 60.0
-        assert cfg.state_machine.poll_interval == 0.5
+        assert cfg.state_machine.poll_interval == 1.0
 
     def test_frozen(self) -> None:
         cfg = STS2Config()

--- a/tests/unit/test_journey_foreground.py
+++ b/tests/unit/test_journey_foreground.py
@@ -320,3 +320,84 @@ def test_success_path_captures_final_state_screenshot(
     # 终态凭证携带的必须是最终状态本身
     final_state = next(state for name, state in captured if "_FINAL_" in name)
     assert final_state["screen"] == "COMBAT"
+
+
+def _cancel_recovery_dict(**overrides: object) -> dict:
+    """构造与 _recover_main_menu_via_restart 返回值同形状的恢复结果。"""
+    base: dict = {
+        "target": "MAIN_MENU",
+        "recovery_method": "controlled_restart",
+        "normal_menu_abandon": False,
+        "restart_count": 0,
+        "final_screen": "MAIN_MENU",
+        "clean_main_menu": True,
+        "old_run_abandoned": False,
+        "reason": None,
+        "final_state": {"screen": "MAIN_MENU"},
+        "ok": True,
+        "blocked": False,
+    }
+    base.update(overrides)
+    return base
+
+
+def test_cancel_result_restart_count_promoted_to_report_top_level() -> None:
+    """B1 契约：取消收尾报告（生产构造点）把真实 restart_count 提升到顶层。
+
+    审查 B1：重启计数此前嵌套在 recovery 子 dict，report_html 只认顶层 key，
+    「重启次数」卡片在生产路径永不渲染。本测试绑定生产构造函数 + 与 write_result
+    相同的顶层展开 + build_report_html 渲染，防止渲染端/生产端再次错配。
+    """
+    from sts2_autotest.cli.main import _build_cancel_result
+    from sts2_autotest.report_html import build_report_html
+
+    cancel_result = _build_cancel_result(
+        duration_ms=1234,
+        trajectory=["MAIN_MENU", "COMBAT"],
+        pre_cancel_state={"screen": "COMBAT"},
+        recovered_state={"screen": "MAIN_MENU"},
+        last_action="end_turn",
+        journey_evidence={},
+        evidence_dir="/tmp/evidence/run-x",
+        recovery=_cancel_recovery_dict(restart_count=1),
+        lifecycle=object(),  # lifecycle 可用 → 受控重启恢复路径真实执行过
+    )
+
+    # 契约 1：顶层提升（write_result 用 payload.update(extra) 展开到 run-result.json）
+    assert cancel_result["restart_count"] == 1
+    assert cancel_result["recovery"]["restart_count"] == 1
+
+    # 契约 2：run-result.json 顶层形状 → HTML 渲染「重启次数」卡片
+    payload: dict = {"run_id": "run-x", "task_id": "run-x", "status": "CANCELLED"}
+    payload.update(cancel_result)
+    html = build_report_html(payload)
+    assert '<div class="num">1</div>重启次数' in html
+
+
+def test_cancel_result_omits_restart_count_without_real_source() -> None:
+    """B1 契约：无真实数据源（lifecycle 不可用）→ 顶层不写 restart_count。
+
+    与 relaunch_count 同口径：有真实数据源才写、无则不写，禁止编造 0。
+    """
+    from sts2_autotest.cli.main import _build_cancel_result
+    from sts2_autotest.report_html import build_report_html
+
+    cancel_result = _build_cancel_result(
+        duration_ms=1234,
+        trajectory=["MAIN_MENU"],
+        pre_cancel_state=None,
+        recovered_state=None,
+        last_action=None,
+        journey_evidence={},
+        evidence_dir=None,
+        recovery=_cancel_recovery_dict(),  # lifecycle 缺失时的 fallback 形状（0 为编造值）
+        lifecycle=None,
+    )
+
+    assert "restart_count" not in cancel_result
+    assert cancel_result["recovery"]["restart_count"] == 0  # 子 dict 原样保留
+
+    payload: dict = {"run_id": "run-x", "task_id": "run-x", "status": "CANCELLED"}
+    payload.update(cancel_result)
+    html = build_report_html(payload)
+    assert "重启次数" not in html

--- a/tests/unit/test_lifecycle.py
+++ b/tests/unit/test_lifecycle.py
@@ -442,3 +442,33 @@ def test_game_exe_not_hardcoded_to_user_path():
     assert "/Users/chris" not in src
     mgr = GameLifecycleManager(_ProbeAdapter(), game_dir="/opt/steam/StS2")
     assert mgr.game_exe.startswith("/opt/steam/StS2")
+
+
+# ── 阶段 C：重拉上限默认下调（issue #37）───────────────────
+
+
+class TestMaxRelaunches:
+    def test_default_max_relaunches_downgraded_to_3(self) -> None:
+        """默认重拉上限从 15 下调至 3——确定性失败不再空转 15 次。"""
+        mgr = _mgr(FakeAdapter([]))
+        assert mgr.max_relaunches == 3
+
+    def test_custom_max_relaunches(self) -> None:
+        mgr = GameLifecycleManager(
+            FakeAdapter([]), game_exe="/tmp/fake_game",
+            game_dir="/tmp/fake_dir", max_relaunches=5,
+        )
+        assert mgr.max_relaunches == 5
+
+    def test_relaunch_run_stops_at_custom_cap(self, no_sleep, fake_popen) -> None:
+        """自定义上限 1：第 1 次重拉后到达上限，后续调用拒绝且计数不涨。"""
+        mgr = GameLifecycleManager(
+            FakeAdapter([], down_first=0), game_exe="/tmp/fake_game",
+            game_dir="/tmp/fake_dir", max_relaunches=1,
+        )
+        ok1 = asyncio.run(mgr.relaunch_run(api_timeout=1.0))
+        ok2 = asyncio.run(mgr.relaunch_run(api_timeout=1.0))
+        assert ok1 is False  # API 未恢复（down_first=0 但响应为空 → is_api_up False）
+        assert mgr.relaunch_count == 1
+        assert ok2 is False
+        assert mgr.relaunch_count == 1  # 已达上限，不再递增

--- a/tests/unit/test_orchestrator.py
+++ b/tests/unit/test_orchestrator.py
@@ -524,6 +524,45 @@ class TestHandleFailure:
         assert len(orch._failure_history) == 1
         assert orch._failure_history[0].error_type == "timeout_error"
 
+    def test_failure_record_includes_signature(self) -> None:
+        """FailureRecord created by _handle_failure must include deterministic signature."""
+        mock = _make_mock_adapter()
+        evidence = MagicMock()
+        evidence.on_case_end = MagicMock()
+        orch = TestOrchestrator(adapter=mock, evidence=evidence)
+        exc = STS2Error(
+            category=ErrorCategory.CRASH_ERROR,
+            message="Game process died",
+            detail={"exit_code": 1},
+        )
+        _run(orch._handle_failure("TC-001", exc))
+        assert len(orch._failure_history) == 1
+        assert orch._failure_history[0].signature == "STS2Error:1"
+
+    def test_same_crash_signature_shortcut_terminates(self) -> None:
+        """Two same crash signatures in a row trigger deterministic_fail via shortcut."""
+        mock = _make_mock_adapter()
+        evidence = MagicMock()
+        evidence.on_case_end = MagicMock()
+        orch = TestOrchestrator(adapter=mock, evidence=evidence)
+        orch._failure_history = [
+            FailureRecord(
+                error_type=ErrorCategory.CRASH_ERROR.value,
+                message="first crash",
+                timestamp="t1",
+                exit_code=1,
+                signature="STS2Error:1",
+            ),
+        ]
+        exc = STS2Error(
+            category=ErrorCategory.CRASH_ERROR,
+            message="second crash",
+            detail={"exit_code": 1},
+        )
+        result = _run(orch._handle_failure("TC-001", exc))
+        assert result.status == "deterministic_fail"
+        assert orch._failure_history[-1].signature == "STS2Error:1"
+
     def test_consecutive_failures_triggers_deterministic_fail(self) -> None:
         mock = _make_mock_adapter()
         evidence = MagicMock()

--- a/tests/unit/test_recovery_strategy.py
+++ b/tests/unit/test_recovery_strategy.py
@@ -667,3 +667,104 @@ class TestExecuteFullRestart:
         mock_steam.stop_steam.assert_not_called()
         mock_steam.start_steam.assert_not_called()
         mock_steam.start_game.assert_not_called()
+
+
+# ── 阶段 C：相同失败签名短路（issue #37）───────────────────
+
+
+def _crash_error(exit_code: int | None = None, message: str = "crash") -> STS2Error:
+    """构造 CRASH_ERROR 类 STS2Error（可选 exit_code）。"""
+    detail = {"exit_code": exit_code} if exit_code is not None else {}
+    return STS2Error(category=ErrorCategory.CRASH_ERROR, message=message, detail=detail)
+
+
+class TestSameSignatureShortcut:
+    """连续相同失败签名 → 直接 TERMINATE，不再 GAME_RESTART/FULL_RESTART 空转。"""
+
+    @pytest.fixture
+    def strategy(self) -> DefaultRecoveryStrategy:
+        return DefaultRecoveryStrategy()
+
+    def test_terminates_on_repeated_same_signature(
+        self, strategy: DefaultRecoveryStrategy
+    ) -> None:
+        """连续 2 次相同失败签名 → TERMINATE（默认短路阈值 2），判定非 P0。"""
+        error = _crash_error(exit_code=1)
+        history = [
+            FailureRecord(
+                error_type=ErrorCategory.CRASH_ERROR.value,
+                message="crash A",
+                timestamp="2026-01-01T00:00:00Z",
+                exit_code=1,
+                signature=crash_signature(error, 1),
+            ),
+        ]
+        decision = strategy.decide(error, history)
+        assert decision.action == RecoveryAction.TERMINATE
+        assert decision.is_p0 is False
+
+    def test_first_crash_still_gets_one_restart(
+        self, strategy: DefaultRecoveryStrategy
+    ) -> None:
+        """首次 crash（无历史）仍走 GAME_RESTART——不掩盖可能瞬时的一次崩溃。"""
+        decision = strategy.decide(_crash_error(exit_code=1), [])
+        assert decision.action == RecoveryAction.GAME_RESTART
+
+    def test_different_signatures_keep_progressive_restart(
+        self, strategy: DefaultRecoveryStrategy
+    ) -> None:
+        """不同签名（不同 exit_code）→ 仍按渐进恢复：第 2 次 → FULL_RESTART。"""
+        error = _crash_error(exit_code=1)
+        history = [
+            FailureRecord(
+                error_type=ErrorCategory.CRASH_ERROR.value,
+                message="crash B",
+                timestamp="2026-01-01T00:00:00Z",
+                exit_code=2,
+                signature="STS2Error:2",
+            ),
+        ]
+        decision = strategy.decide(error, history)
+        assert decision.action == RecoveryAction.FULL_RESTART
+
+    def test_legacy_records_without_signature_keep_progressive(
+        self, strategy: DefaultRecoveryStrategy
+    ) -> None:
+        """历史记录无 signature（旧格式）→ 保持原渐进逻辑，不短路。"""
+        error = _crash_error(exit_code=1)
+        history = [
+            FailureRecord(
+                error_type=ErrorCategory.CRASH_ERROR.value,
+                message="crash C",
+                timestamp="2026-01-01T00:00:00Z",
+                exit_code=1,
+            ),
+        ]
+        decision = strategy.decide(error, history)
+        assert decision.action == RecoveryAction.FULL_RESTART
+
+    def test_custom_shortcut_threshold(
+        self, strategy: DefaultRecoveryStrategy
+    ) -> None:
+        """same_signature_shortcut=3 → 第 2 次相同签名不短路（仍 FULL_RESTART）。"""
+        error = _crash_error(exit_code=1)
+        history = [
+            FailureRecord(
+                error_type=ErrorCategory.CRASH_ERROR.value,
+                message="crash D",
+                timestamp="2026-01-01T00:00:00Z",
+                exit_code=1,
+                signature="STS2Error:1",
+            ),
+        ]
+        decision = strategy.decide(error, history, same_signature_shortcut=3)
+        assert decision.action == RecoveryAction.FULL_RESTART
+
+    def test_signature_field_defaults_to_empty(
+        self, strategy: DefaultRecoveryStrategy
+    ) -> None:
+        """FailureRecord.signature 默认空串——旧构造代码无需改动。"""
+        record = FailureRecord(
+            error_type="timeout_error", message="x", timestamp="t",
+        )
+        assert record.signature == ""

--- a/tests/unit/test_report_html.py
+++ b/tests/unit/test_report_html.py
@@ -364,3 +364,33 @@ def test_write_html_report_writes_temp_file_before_replace(
     assert written_paths
     assert written_paths[0] != output_path
     assert output_path.is_file()
+
+
+def test_report_renders_restart_and_relaunch_counts(tmp_path):
+    """阶段 C：报告暴露重启/重拉计数，可对比改造前后（0 也显示）。"""
+    config = {
+        "test_run_id": "perf-run",
+        "test_cases": [],
+        "card_results": [],
+        "restart_count": 2,
+        "relaunch_count": 0,
+        "_config_dir": str(tmp_path),
+    }
+    html = build_report_html(config)
+
+    assert '<div class="num">2</div>重启次数' in html
+    assert '<div class="num">0</div>重拉次数' in html
+
+
+def test_report_omits_counter_cards_when_not_provided(tmp_path):
+    """未提供计数（既有报告格式）→ 不渲染计数卡，避免破坏旧报告。"""
+    config = {
+        "test_run_id": "demo-run",
+        "test_cases": [],
+        "card_results": [],
+        "_config_dir": str(tmp_path),
+    }
+    html = build_report_html(config)
+
+    assert "重启次数" not in html
+    assert "重拉次数" not in html


### PR DESCRIPTION
Closes #37（Draft 阶段）

## 背景

`adapters/cli_mod.py` 每次调用都经 `_run_cli` 做全新 `subprocess.Popen(["sts2", ...])`。一场战斗最多 80 步，每步约 2 次工具启动（读状态 + 执行动作）；游戏进程还因「确定性失败反复重启」存在大量无效重启。本期（阶段 A + C，阶段 B deferred）压这两类开销。

## 阶段 A：降频 + 去重

1. **`_run_cli` 入口埋点 `cli_launch_count`**：每次工具启动（含失败）计数，统计口径 = 实际启动次数，为「同场战斗启动次数 ↓≥50%」验收提供度量。
2. **战斗等待自适应降频**（`_combat_basic_policy_sync`）：非玩家回合（状态未变）等待间隔逐轮翻倍、封顶 2×`poll_interval`（默认 0.5s → 0.5/1.0/1.0…），玩家回合复位基础间隔；每轮仍强制重读状态，检测语义不变。
3. **`CliModAdapter(poll_interval=…)` 构造参数化**。
4. **`config.schema` `poll_interval` 默认 0.5s → 1.0s**（状态机轮询全局默认降频；去重为主、轮询间隔为次要调参 —— 拍板：issue 缺口 #2）。
5. `dsl/fluent.py`：本期不改（settle 已有 `settle_poll_interval` 可配置参数，无测试需求则不动）。

## 阶段 C：减少可避免重启

1. **相同失败签名短路**（`core/recovery.py`）：`FailureRecord.signature` 新字段（默认空串，旧格式兼容）；`decide(…, same_signature_shortcut=2)` —— 连续 2 次相同 `CRASH_ERROR` 签名 → 直接 `TERMINATE`（is_p0=False），不再 GAME_RESTART/FULL_RESTART 空转；**不改变任何失败判定**（短路后仍 FAILED/BLOCKED，照常上报）。
   - **拍板：短路阈值 N = 2**（issue 缺口 #3，建议区间 2–3 取下限：确定性失败 2 次即止损，瞬态仍有 1 次 GAME_RESTART 机会）。
2. **重拉上限收敛**（`core/lifecycle.py`）：`max_relaunches` 默认 15 → 3，仍可构造参数覆盖；上限处拒绝 + 计数不涨行为已有测试覆盖。
3. **重启/重拉计数进报告**（`report_html.py` + `cli/main.py`）：HTML 报告渲染「重启次数/重拉次数」计数卡（哪个 key 提供渲染哪张、0 也显示、未提供不渲染不破坏旧报告）；旅程 PASSED 结果写入真实 `lifecycle.relaunch_count`；取消收尾报告把受控重启恢复路径的真实 `restart_count` 提升到顶层（同口径：有真实数据源才写、无则不写，禁止编造 0），detach 合成路径一并携带。

## 复审修复（S3 测试阶段 + S4 评审 B1）

- **S3 逃逸缺陷修复**：`orchestrator.py` 创建 `FailureRecord` 时未填充 `signature`，导致相同签名短路在生产路径永不触发。修复 = `failure_signature(exc)` 公共化 + orchestrator 构造点填充；新增 2 条编排器契约回归测试（先失败后修复）。
- **S4 B1（阻塞）修复**：取消收尾报告的 `restart_count` 此前嵌套在 `recovery` 子 dict，`report_html` 只认顶层 key，「重启次数」卡片在生产路径永不渲染。修复 = 提取 `_build_cancel_result` 生产构造函数（取消报告唯一构造点）提升顶层计数 + `_report_from_store` 合成白名单加入 `restart_count`；补 3 条「生产构造点 → run-result.json 顶层形状 → build_report_html 渲染」端到端契约测试（先失败后修复）。
- **非阻塞项**（评审 N1-N5）：模块常量收敛等留待后续，不随本期；工作区 `tests/generated/` 残留（import 重排）未入提交。

## 明确不做

- ❌ 不改 sts2 本体（阶段 B 常驻连接，deferred，依赖 sts2 本体团队接口对齐）
- ❌ 不重写导航正确性逻辑
- ❌ 不改 AgentAdapter
- ❌ 阶段 C 不改变任何测试通过/失败判定

## 验收缺口处置（issue #37 自报）

- 缺口 #1「目标机器基准」：阻塞项按流程流转（人工门禁决策）；量化验收以相对指标为准（启动 ↓≥50%、确定性失败重启 ↓≥70% 均为相对度量，任意机器可复现）；「耗时 ↓≥30%」需在目标机器复测。
- 缺口 #2「降频目标值」：拍板 = 去重为主（等待退避翻倍封顶），轮询默认 0.5s→1.0s 为次要调参。
- 缺口 #3「短路阈值 N」：拍板 = 2。

## 测试

- 单元测试：`tests/unit/` 全量 **1831 passed**（含 B1 契约 3 例 + S3 回归 2 例）
- 集成测试：**30 passed, 5 skipped**（requires_game 无游戏环境自动跳过）
- `scripts/verify.sh`（含 `BASELINE_DIR` 增量门禁）：**全绿** —— shell 脚本测试 / 单元测试 / lint-imports / ruff 无新增债务（baseline 2, current 2）/ mypy 无新增债务（baseline 5, current 5）

## 备注

- 工作区遗留的前序开发尝试测试（阶段 A/C TDD RED）经复核纳入；3 处测试断言按真实行为修正（`health_check` 不传播异常改用 `get_state`；两处启动计数补上最终判定读取与 play_card 响应），行为规格未变。
- 环境注意：`tests/unit/test_cli.py::test_precheck_true_blocks_before_journey` 在「Steam 可自动发现游戏目录」的机器上会真实拉起游戏（`_ensure_clean_main_menu` → 受控重启），游戏就绪后约 4-5 分钟通过——属既有环境依赖行为（基线同样复现），非本期引入；目标机器跑全量前确认游戏环境即可。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
