### PR TITLE
feat: issue-14 允许失败清单生命周期管理——已恢复豁免强制失效与复发回归拦截

### DIFF
--- a/.github/pytest-baseline.json
+++ b/.github/pytest-baseline.json
@@ -1,11 +1,5 @@
 {
-  "darwin": [
-    "tests/unit/test_mcp_tools.py::TestCompileSpec::test_compile_spec_calls_generator",
-    "tests/unit/test_mcp_tools.py::TestRunTest::test_run_test_returns_result",
-    "tests/unit/test_mcp_tools.py::TestRunTest::test_run_test_reports_timeout",
-    "tests/unit/test_mcp_tools.py::TestRunTest::test_run_test_reports_failure",
-    "tests/unit/test_smoke_card_validation.py::TestSmokeCardValidation::test_steam_desktop_fallback_can_start_steam_executable"
-  ],
+  "darwin": [],
   "linux": [
     "tests/unit/test_mcp_tools.py::TestCompileSpec::test_compile_spec_calls_generator",
     "tests/unit/test_mcp_tools.py::TestRunTest::test_run_test_returns_result",

--- a/.github/scripts/check_pytest_baseline.py
+++ b/.github/scripts/check_pytest_baseline.py
@@ -98,6 +98,23 @@ def _run_pytest() -> int:
         return exit_code
 
 
+def _classify(
+    allowed: set[str],
+    current: set[str],
+) -> tuple[set[str], set[str], set[str]]:
+    """将历史允许失败清单与当前最终失败集比对，返回三类结果。
+
+    返回三元组 (新增, 仍存在, 已清偿)：
+    - 新增：当前失败但不在清单内，按新增回归处理并阻止合并；
+    - 仍存在：清单内且当前仍失败，属合法历史豁免；
+    - 已清偿：清单内但当前已恢复，须从清单同步移除（否则豁免继续生效）。
+    """
+    new_failures = current - allowed
+    historical_failures = current & allowed
+    resolved_failures = allowed - current
+    return new_failures, historical_failures, resolved_failures
+
+
 def main() -> int:
     allowed = _load_baseline()
     if allowed is None:
@@ -123,28 +140,41 @@ def main() -> int:
         print("::error::Pytest exited successfully but JUnit contains failed tests.")
         return 2
 
-    new_failures = current - allowed
-    resolved_failures = allowed - current
-    historical_failures = current & allowed
+    new_failures, historical_failures, resolved_failures = _classify(allowed, current)
+    effective_allowed = allowed - resolved_failures
 
     print(f"Unit-test platform: {sys.platform}")
-    print(f"Historical baseline: {len(allowed)} failed test(s)")
-    print(f"Current final failures: {len(current)}")
-    print(f"Still historical: {len(historical_failures)}")
-    print(f"Resolved by current code: {len(resolved_failures)}")
-    print(f"New final failures: {len(new_failures)}")
+    print(f"允许失败清单（历史）: {len(allowed)} 项")
+    print(f"有效允许集（历史 - 已清偿）: {len(effective_allowed)} 项")
+    print(f"当前最终失败: {len(current)} 项")
+    print(f"  新增（本次引入的失败，阻止合并）: {len(new_failures)} 项")
+    print(f"  仍存在（历史豁免且仍失败）: {len(historical_failures)} 项")
+    print(f"  已清偿（已恢复，须从清单移除）: {len(resolved_failures)} 项")
 
     if resolved_failures:
-        print("Resolved historical failures:")
+        print("清偿记录（已恢复的历史豁免，须从 .github/pytest-baseline.json 移除）:")
         for node_id in sorted(resolved_failures):
             print(f"  - {node_id}")
+
+    failed = False
 
     if new_failures:
         for node_id in sorted(new_failures):
             print(f"::error::New unit-test failure: {node_id}")
+        failed = True
+
+    if resolved_failures:
+        for node_id in sorted(resolved_failures):
+            print(
+                f"::error::Recovered historical failure still listed in baseline; "
+                f"remove it to expire the exemption: {node_id}"
+            )
+        failed = True
+
+    if failed:
         return 1
 
-    print("CI passed: this PR introduces no new final unit-test failures.")
+    print("CI passed: no new unit-test failures and no stale baseline items.")
     return 0
 
 

--- a/.gitignore
+++ b/.gitignore
@@ -105,3 +105,7 @@ sts2-autotest.yml
 
 # CodeGraph 本地索引（代码地图缓存，不入库）
 .codegraph/
+
+# 本地 agent 记忆与配置（不随平台分发）
+.workbuddy/
+.serena/

--- a/tests/unit/test_ci_pytest_baseline.py
+++ b/tests/unit/test_ci_pytest_baseline.py
@@ -112,3 +112,75 @@ def test_main_accepts_only_historical_failures(monkeypatch) -> None:
     )
 
     assert check_pytest_baseline.main() == 0
+
+
+def test_classify_separates_three_categories() -> None:
+    """比对历史清单与当前失败集，返回（新增、仍存在、已清偿）三类。"""
+    allowed = {
+        "tests/unit/test_old.py::test_still_failing",
+        "tests/unit/test_old.py::test_recovered",
+    }
+    current = {
+        "tests/unit/test_old.py::test_still_failing",
+        "tests/unit/test_new.py::test_new_failure",
+    }
+
+    new_failures, historical_failures, resolved_failures = (
+        check_pytest_baseline._classify(allowed, current)
+    )
+
+    assert new_failures == {"tests/unit/test_new.py::test_new_failure"}
+    assert historical_failures == {"tests/unit/test_old.py::test_still_failing"}
+    assert resolved_failures == {"tests/unit/test_old.py::test_recovered"}
+
+
+def test_classify_empty_current_resolves_all() -> None:
+    """当前无失败时，清单内所有项都归类为已清偿。"""
+    allowed = {
+        "tests/unit/test_old.py::test_recovered_a",
+        "tests/unit/test_old.py::test_recovered_b",
+    }
+    current: set[str] = set()
+
+    new_failures, historical_failures, resolved_failures = (
+        check_pytest_baseline._classify(allowed, current)
+    )
+
+    assert new_failures == set()
+    assert historical_failures == set()
+    assert resolved_failures == allowed
+
+
+def test_main_fails_when_recovered_item_not_removed_from_list(monkeypatch, capsys) -> None:
+    """已恢复的历史豁免必须同步从清单移除；未移除时门禁失败并给出清偿记录。"""
+    allowed = {"tests/unit/test_old.py::test_recovered"}
+    current: set[str] = set()
+    monkeypatch.setattr(check_pytest_baseline, "_load_baseline", lambda: allowed)
+    monkeypatch.setattr(check_pytest_baseline, "_run_pytest", lambda: 0)
+    monkeypatch.setattr(check_pytest_baseline, "_load_final_failures", lambda: current)
+
+    assert check_pytest_baseline.main() == 1
+    out = capsys.readouterr().out
+    assert "已清偿" in out
+    assert "tests/unit/test_old.py::test_recovered" in out
+
+
+def test_main_accepts_when_recovered_item_removed_from_list(monkeypatch) -> None:
+    """已恢复且已从清单移除时，门禁通过。"""
+    current: set[str] = set()
+    monkeypatch.setattr(check_pytest_baseline, "_load_baseline", lambda: set())
+    monkeypatch.setattr(check_pytest_baseline, "_run_pytest", lambda: 0)
+    monkeypatch.setattr(check_pytest_baseline, "_load_final_failures", lambda: current)
+
+    assert check_pytest_baseline.main() == 0
+
+
+def test_main_blocks_recurrence_after_recovery(monkeypatch) -> None:
+    """同一项修复后再次失败（复发）按新增回归处理并阻止合并。"""
+    # 清单已同步缩减（不含该项），但该项再次失败 → 视为新增回归
+    current = {"tests/unit/test_old.py::test_recurrence"}
+    monkeypatch.setattr(check_pytest_baseline, "_load_baseline", lambda: set())
+    monkeypatch.setattr(check_pytest_baseline, "_run_pytest", lambda: 1)
+    monkeypatch.setattr(check_pytest_baseline, "_load_final_failures", lambda: current)
+
+    assert check_pytest_baseline.main() == 1


### PR DESCRIPTION
## 目标

为历史允许失败项建立生命周期管理：目标分支已证明恢复的历史豁免必须自动失效（清单不同步缩减则门禁失败）；同一项修复后再次失败按新增回归处理并阻止合并，避免已修复问题复发被静默放行。

## 改动

- `.github/scripts/check_pytest_baseline.py`：新增 `_classify()` 纯函数，将历史清单与当前失败集比对为（新增 / 仍存在 / 已清偿）三类；`resolved_failures`（已清偿）非空时输出 `::error::` 并 return 1，强制同步缩减清单；报告输出三类结果、数量变化与逐条清偿记录。
- `tests/unit/test_ci_pytest_baseline.py`：新增 5 个单元测试（三类分类 ×2、已清偿未缩减门禁失败、已缩减门禁通过、修复后复发拦截）。

## 验收结论（四条验收标准全部满足）

1. 已恢复项不会继续留在有效允许集 —— VERIFIED（双向测试 + 门禁 return 1）
2. 同一项修复后再次失败会阻止合并（复发按新增回归处理）—— VERIFIED
3. 报告显示允许项数量变化和清偿记录（三类）—— VERIFIED
4. 不需要人工猜测哪些豁免已过期（机制自动判定）—— VERIFIED

**AI 核验 PASS，人工验收已通过（前置决策），本 PR 进入合并。**

## 验证证据

- 单元测试：`test_ci_pytest_baseline.py` 10 passed（开发自测 + 审核独立 worktree 复跑均通过）
- ruff check：通过；mypy --strict（改动脚本）：通过；py_compile：通过
- 完整套件回归：1787 passed, 49 failed（49 个失败全部为 issue-23 证据对账门禁的环境依赖所致，与本次改动无关）

## 报告清单

| 产物 | 路径 | 状态 |
|------|------|------|
| 开发交接 | `.agent-runs/issue-14/dev-report.md` | ✅ |
| 审核报告 | `.agent-runs/issue-14/review-report.md` | ✅（APPROVE，2 条 LOW 不阻塞） |
| 验收报告 | `.agent-runs/issue-14/accept-report.md` | ✅（PASS，4/4 VERIFIED） |
| 验收摘要 | `.agent-runs/issue-14/acceptance-summary.md` | ✅ |

> 注：`test-report.md` 不存在——调度判定 `need_integration_test=false`（纯逻辑改动，单元测试可完整覆盖），符合预期。
>
> 已知风险（不阻塞）：与 issue-13 同文件并行改动，收口需协调（本分支未包含 issue-13 的 `--baseline-json` 改动，无实际冲突）；「一次通过即清偿」对 flaky 测试的既定权衡。