### PR TITLE
[probe-B] 探针：新增 .ruff.toml 降低 Ruff 规则

### DIFF
--- a/.ruff.toml
+++ b/.ruff.toml
@@ -1,0 +1,2 @@
+[lint]
+ignore = ["E501"]


### PR DESCRIPTION
> 反向验证探针（issue-21 探针 B）：新增 .ruff.toml 忽略 E501 规则，验证 code owner review 阻止。

预期：作者 @crystepj-max 无法自我审批 code owner review → merge 被拒。

> *This probe PR was generated by AI during issue-21 reverse validation.*