### PR TITLE
[probe-A] 探针：新增失败 + 扩大允许失败清单

### DIFF
--- a/.github/pytest-baseline.json
+++ b/.github/pytest-baseline.json
@@ -1,5 +1,7 @@
 {
-  "darwin": [],
+  "darwin": [
+    "tests/unit/test_probe_failure.py::test_always_fails"
+  ],
   "linux": [
     "tests/unit/test_mcp_tools.py::TestCompileSpec::test_compile_spec_calls_generator",
     "tests/unit/test_mcp_tools.py::TestRunTest::test_run_test_returns_result",

--- a/tests/unit/test_probe_failure.py
+++ b/tests/unit/test_probe_failure.py
@@ -1,0 +1,7 @@
+"""探针 A：必然失败的单元测试（issue-21 反向验证，勿合入）。"""
+
+from __future__ import annotations
+
+
+def test_always_fails() -> None:
+    assert False, "探针 A 故意失败"


### PR DESCRIPTION
> 反向验证探针（issue-21 探针 A）：新增必然失败的单元测试，并同时把该失败加入 `.github/pytest-baseline.json` 允许清单，验证 `--baseline-json` 从 base SHA 读取能识别新增失败。

预期：即使当前清单被篡改，CI 的 `check_pytest_baseline.py --baseline-json .ci-baseline/...` 仍识别 `tests/unit/test_probe_failure.py::test_always_fails` 为新增失败 → PR Check Summary 失败 → merge 被拒。

> *This probe PR was generated by AI during issue-21 reverse validation.*