### PR TITLE
[probe-C] 探针：修改 mypy-policy.ini 降低严格度

### DIFF
--- a/.github/mypy-policy.ini
+++ b/.github/mypy-policy.ini
@@ -1,6 +1,6 @@
 # mypy 政策参数（issue-21 决策 03）。
 # 本文件为检查政策文件，变更必须走独立政策变更 PR（issue-21 决策 05）。
 [mypy]
-strict = True
+strict = False
 show_error_codes = True
 no_error_summary = True


### PR DESCRIPTION
## 探针 PR（issue-21 反向验证）

这是 issue #21「防止质量门槛被基线、规则或依赖变更绕过」的反向验证探针 C。

- **探针目标**：路径 3「弱化类型检查规则或缩小检查范围」
- **模拟绕过**：将 `.github/mypy-policy.ini` 中 `strict = True` 改为 `strict = False`（降低 mypy 严格度）
- **预期结果**：`require_code_owner_review` 生效 → 作者（唯一 code owner）无法自我审批政策文件变更 → merge 被拒绝
- **处置**：验证完成后关闭，**不合并**

> AI 生成内容免责声明：本 PR 由 AI 自动化生成，用于 issue-21 反向验证探针，非真实功能变更。
