### PR TITLE
[probe-D] 探针：修改 pyproject.toml 升级 ruff 依赖

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ visual = [
     "opencv-python-headless>=4.10.0",
 ]
 dev = [
-    "ruff>=0.1.0",
+    "ruff>=0.99.0",
     "mypy>=1.0",
     "import-linter>=2.0",
     "pytest-mock>=3.0",


### PR DESCRIPTION
## 探针 PR（issue-21 反向验证）

这是 issue #21「防止质量门槛被基线、规则或依赖变更绕过」的反向验证探针 D。

- **探针目标**：路径 4「修改依赖条件，污染目标分支与当前变更的比较结果」
- **模拟绕过**：将 `pyproject.toml` dev 依赖中 `ruff>=0.1.0` 改为 `ruff>=0.99.0`（模拟通过依赖升级改变检查工具版本）
- **预期结果**：`require_code_owner_review` 生效（CODEOWNERS 覆盖 `pyproject.toml`）→ 作者无法自我审批 → merge 被拒绝；技术层 CI 仍使用 `.github/requirements-lint.txt` 固定的 `ruff==0.15.22`（可观察）
- **处置**：验证完成后关闭，**不合并**

> AI 生成内容免责声明：本 PR 由 AI 自动化生成，用于 issue-21 反向验证探针，非真实功能变更。
