### PR TITLE
perf: 启动宽限期 + 游戏内放弃优先，避免测试中误杀游戏进程

### DIFF
--- a/reports/handoff-20260819-game-restart-fix.md
+++ b/reports/handoff-20260819-game-restart-fix.md
@@ -1,0 +1,120 @@
+# 交接文档：修复「测试时游戏被频繁重启」（启动即二次拉起）
+
+- **交接日期**：2026-08-19（本地 20:50，UTC+8）
+- **交接人**：WorkBuddy 会话（grill-with-docs 追问 + 根因排查）
+- **接手人**：后续任意 agent
+- **会话背景**：对腾讯文档 `[PERF] CliMod 适配器每次调用重启子进程 (P1)`（file_id `PNOPEsocVTPY`，https://docs.qq.com/markdown/DUE5PUEVzb2NWVFBZ?_fid=PNOPEsocVTPY ）做事实核验时，用户指出真正关心的问题不是「CLI 子进程冷启动」，而是**游戏本体进程在自动化测试时被频繁重启**（一次启动后不到 1 分钟又被拉起）。
+
+---
+
+## 1. 任务目标（用户原话要点）
+
+> 开发工作流跑到集成测试/回归测试环节，autotest MCP 服务启动游戏后，不到 1 分钟又启动一次。第一次启动时屏幕切到游戏画面，不到 1 分钟又因启动游戏切回游戏画面。
+> 理想期望：自动化测试时**不需要重启游戏**；即便做不到，也不希望频繁重启。
+> 用户极少遇到崩溃/卡死，怀疑是「游戏还未启动成功，就被误诊为崩溃/未就绪」导致。
+
+**成功标准（可验收）**：集成/回归测试启动游戏后，不再出现「启动后 ≤1 分钟被再次拉起」；需要重开一局时优先走游戏内「系统设置→放弃游戏→确认」回主菜单，硬重启仅作兜底。
+
+---
+
+## 2. 已确认根因（带代码证据）
+
+### 根因 A（主因）——启动误诊为陈旧进程 → 杀 A 拉 B
+
+触发链：
+1. `test_agent_runner._step_launch_game`（`src/sts2_autotest/core/test_agent_runner.py:1046`）拉起游戏实例 A；
+2. 紧接着预检 `ensure_environment_ready`（`src/sts2_autotest/cli/main.py:2125`，集成/回归前的环境就绪门）**不等待启动完成**就被调用；
+3. `ensure_environment_ready`（`src/sts2_autotest/core/lifecycle.py:590-709`）中 `_probe_ready` 对「进程在、但屏幕仍是 UNKNOWN / 主菜单动作列表为空（模组未加载完）」判定为 `GAME_PROCESS_STALE` → **立即 terminate + 重新 launch**。
+
+→ 这就是「启动后不到 1 分钟又被拉起」的可避免根因。
+
+对照：`cli/main.py:813` 的取消恢复路径是正确的——terminate 后 launch，再 `wait_for_controllable`（`lifecycle.py:445`，`api_timeout=150s`）等待启动完成。`ensure_environment_ready` 没复用这个等待。
+
+### 根因 B（次因）——Mid-run 重置直接硬重启，不用游戏内放弃
+
+- `orchestrator._auto_reset_to_main_menu`（`src/sts2_autotest/core/orchestrator.py:242`）在需要把游戏重置回主菜单时，遇到 `MAP`/`COMBAT`（一局进行中）**直接 break 跳去硬重启**（杀进程+重拉），注释假设「进行中的局无法软导航到主菜单」——**该假设错误**。
+- 框架其实**已具备**游戏内「放弃」能力：`abandon_run` 动作（`adapters/cli_mod.py:781` 直接 `_run_cli("abandon_run")`；`adapters/agent.py:509/791` 走 HTTP 且 `abandon_run` 会被映射为战斗内的 die 控制台命令，「只适合运行中」；`core/journeys.py:353` 用 `_act_confirmed("abandon_run")` 处理确认弹窗）。
+- 即：需要重开一局时，本可先「放弃→主菜单→新一局」，框架却选择关掉整个游戏程序冷重启。
+
+### 根因 C（保留，需区分）——真崩溃 / 卡死态
+
+- 任何 `CRASH_ERROR` 第一次发生就直接 `GAME_RESTART`（`core/recovery.py`，原 :306 附近）——真崩溃合理，但「崩溃」可能含误诊的可恢复状态。
+- phantom combat / travel hang → `relaunch_run`（`core/lifecycle.py:122/125`），注释断言「无 in-game 动作能退出」——这条是**真正不可避免的硬重启**，暂维持原逻辑。
+- `core/watchdog.py` 只杀进程不重启，把决策交给 recovery。
+
+---
+
+## 3. 已完成的改动（工作区未提交）
+
+原 WorkBuddy 改动（5 文件）+ 接手会话补齐：
+
+| 文件 | 改动 | 意图 |
+|---|---|---|
+| `src/sts2_autotest/core/orchestrator.py` | ① `_AUTO_RESET_ABANDON_TIMEOUT`；② MAP/COMBAT 先 `_try_abandon_to_main_menu()`；③ 确认框走共享 `_abandon_confirm_action`（`confirm_modal` 优先，否则 `dismiss_modal`）；`start_session` 的 abandon 确认框复用同一 helper | 根因 B（Q9）+ P0 modal 对齐 |
+| `src/sts2_autotest/core/lifecycle.py` | `_wait_until_ready` + `ensure_environment_ready` 启动宽限期 | 根因 A（Q10） |
+| `src/sts2_autotest/core/recovery.py` | `_state_info`、`_abandon_confirm_action`、`_try_soft_reset_to_main_menu`；`_execute_game_restart` 硬重启前软放弃缓冲 | 根因 C + P0 modal 对齐 |
+| `src/sts2_autotest/core/test_agent_runner.py` | Quartz/AppKit 的 `type: ignore` 从 `import-not-found` 改为 `import-untyped` | P0 mypy 三件套（本机已安装这些包） |
+| `tests/unit/test_lifecycle.py` | 宽限期契约：可控不杀 / 耗尽才 terminate+重拉 | 根因 A |
+| `tests/unit/test_orchestrator.py` | abandon 优先/失败兜底/`dismiss_modal`；硬重启单测注入假 Steam，避免真 `start_game` 空等 60s | Q9 + P0 |
+| `tests/unit/test_recovery_strategy.py` | `_try_soft_reset_to_main_menu` 白名单/失败不掩盖崩溃/`dismiss_modal`；GAME_RESTART 软放弃成功则跳过 steam.restart | Q10 缓冲专项单测 |
+
+**不要提交的他人改动**：`tests/generated/*.py` 等生成测试在接手时已是脏工作区，与本任务无关。
+
+### 验证状态（接手会话 2026-08-19 22:03 UTC+8 复跑）
+
+- ✅ 相关单测：`pytest tests/unit/test_lifecycle.py tests/unit/test_orchestrator.py tests/unit/test_orchestrator_lifecycle.py tests/unit/test_recovery_strategy.py -q` → **167 passed in 8.34s**
+- ✅ 全量单测：`pytest tests/unit/ -q` → **1915 passed, 2 warnings in 474.39s**
+- ✅ `mypy src/sts2_autotest --strict` → **Success: no issues found in 71 source files**
+- ✅ `lint-imports` → **1 kept, 0 broken**
+- ✅ `ruff check`（本任务改动文件）→ **All checks passed**
+- ⚠️ 未跑：全量 `ruff check src/ tests/`（仓库无 ruff 配置，主干即有大量既有 style 报错）；集成/`requires_game` 真机测试
+
+---
+
+## 4. 待办任务
+
+### P0 — 收尾质量门禁：**已完成**（2026-08-19 接手会话）
+
+1. 三件套已跑通（见 §3 验证状态）。`test_agent_runner.py` 的 mypy `import-untyped` 已修。
+2. `confirm_modal` / `dismiss_modal` 已抽到 `recovery._abandon_confirm_action`，与 `start_session`、journeys/AgentAdapter 的确认框命名对齐；仅有 `dismiss_modal` 时软放弃也会点掉。
+
+### P1 — Q11：更正腾讯 PERF 文档
+- 文档 `PNOPEsocVTPY` 当前定位是「CLI 子进程冷启动」；应改写为真实问题「**游戏进程在测试中被频繁硬重启**」。
+- 核心修复方向写入：① 优先游戏内放弃（`abandon_run`）而非硬重启；② 启动宽限期防误诊（`ensure_environment_ready` 等待可控再判陈旧）。附本交接 §2 的代码行号佐证。
+- 更新状态：若文档与 issue-37 同源，标注「阶段 A/C 已完成、仅剩阶段 B（常驻进程，5–6 人天，需 CLI 团队对齐接口）」。
+- 说明：WorkBuddy 因自身 429 限流无法继续改文档，已交接手接会话；**不是**腾讯文档服务不可访问。
+
+### P2 — 真机验证（需 Windows 11 / macOS + 游戏环境）
+- 集成/回归流程启动游戏后，观察 **1 分钟内是否仍被二次拉起**（验收根因 A 修复）。
+- 跑一场完整流程验证 Mid-run 重置走「游戏内放弃」而非冷重启（验收根因 B）。
+- 用 `cli_launch_count` 埋点（`cli_mod.py:134/165`，注释注明供「同场战斗启动次数 ↓≥50%」验收）跑 5 场战斗取基线，判断阶段 B（常驻进程）是否值得 5–6 人天。
+
+### P3 — 提交：**本轮已提交代码 + 本 handoff**
+- 范围：`lifecycle.py` / `orchestrator.py` / `recovery.py` / `test_agent_runner.py` / 对应 3 个 `tests/unit/test_*.py` / 本文件。
+- 未纳入：`tests/generated/`、`.tmpdir`、`.DS_Store`、`junit*.xml`（他人/无关脏文件）。
+
+---
+
+## 5. 注意事项 / 坑
+
+1. **WorkBuddy 429 限流**（2026-08-19）：WorkBuddy 调腾讯文档 `get_content`/更新时被自身限流，无法继续干活，因此交接。腾讯文档本身仍可访问；接手会话应直接改 `PNOPEsocVTPY`，不要把「WorkBuddy 限流」当成「文档服务不可用」。
+2. **仓库红线**（AGENTS.md）：不 revert/reset/checkout 未创建的改动；不改 public API 名称/签名；禁止 `model_construct()`；禁止裸 `except:`；新增修改同步单测。
+3. **启动宽限期实现细节**：`_wait_until_ready` 用 `self.api_timeout`（150s）作窗口、`self.poll_interval` 作轮询间隔——单测里把两者调小以提速，真机行为需用默认值再确认一次。
+4. **`_try_soft_reset_to_main_menu` 的屏幕白名单**：`MAP/COMBAT/EVENT/SHOP/REST/CHEST/CARD_REWARD/BOSS_REWARD` 才尝试放弃，干净主菜单直接返回 False 不空转。
+5. 交接文档本身：接手 agent 完成后建议把本文件更新为「已结项」或归档，避免误导后续会话。
+
+---
+
+## 6. 建议 skills（接手 agent 按需加载）
+
+- `sts2-start-game`：游戏启动原则（仅当无进程/证明失效才重拉；进程在加载中要等待不要重启）——与本次修复哲学一致，真机验证时必读。
+- `sts2-independent-run-regression`：独立会话/分模块回归测试方法（127.0.0.1:8080 Agent API、冷重启拿独立新局等）。
+- `sts2-gawain-regression-recovery`：M1–M7 真机回归（若验证目标是 Gawain MOD 全流程）。
+- `test-report-html`：真机验证后产出标准化 HTML 测试报告。
+- `code-review`：提交前按规范+需求双维度审查。
+
+---
+
+## 7. 一句话摘要
+
+根因 = 预检 `ensure_environment_ready` 把「仍在启动的游戏」误判为陈旧进程而杀掉重拉（主因）+ Mid-run 重置不优先用游戏内放弃（次因）。已实现：启动宽限期、放弃优先、崩溃前软放弃缓冲（含 `dismiss_modal` 对齐）。P0 质量门禁已通过（1915 单测 / mypy / lint-imports）。剩余：更正腾讯文档 `PNOPEsocVTPY`、真机验证。

--- a/src/sts2_autotest/core/lifecycle.py
+++ b/src/sts2_autotest/core/lifecycle.py
@@ -545,6 +545,24 @@ class GameLifecycleManager:
             pass
         return False
 
+    async def _wait_until_ready(self, timeout: float) -> bool:
+        """Wait for ``_probe_ready`` to succeed (boot grace period).
+
+        A freshly launched game often sits at ``UNKNOWN`` and the main menu may
+        render before the control mod finishes loading (empty action list).
+        Treating that as a stale/crashed process and restarting it wastes a full
+        game reboot and is the root cause of "launched, then relaunched <1min
+        later" during integration/regression runs. Poll until the three control
+        checks pass or the boot window elapses.
+        """
+        t0 = time.time()
+        while time.time() - t0 < float(timeout):
+            ok, _, _ = await self._probe_ready()
+            if ok:
+                return True
+            await asyncio.sleep(self.poll_interval)
+        return False
+
     async def _probe_ready(self) -> tuple[bool, EnvironmentBlockReason | None, dict[str, Any]]:
         """Run the three control checks: health, state, actions + screen sanity."""
         checks: dict[str, Any] = {
@@ -642,6 +660,25 @@ class GameLifecycleManager:
                 actions_taken=actions_taken,
                 duration_ms=int((time.time() - t0) * 1000),
             )
+
+        # 启动宽限期（Q10）：进程在、但当前不可控，极可能仍在启动（首帧 UNKNOWN；
+        # 主菜单可能先于模组加载完成而显示、动作列表为空）。此时直接 terminate 会
+        # 把慢启动误判为崩溃，触发一次无谓的硬重启。先给足完整启动窗口等其可控，
+        # 超时（确属坏掉）才落入有界恢复终止+单次重拉。
+        if pre_process:
+            if await self._wait_until_ready(self.api_timeout):
+                ok, reason, checks = await self._probe_ready()
+                pre_process = self._game_process_present()
+                if ok:
+                    return EnvironmentReadiness(
+                        ready=True,
+                        recovered=False,
+                        pre_process_present=pre_process,
+                        pre_control_ready=True,
+                        checks=checks,
+                        actions_taken=actions_taken,
+                        duration_ms=int((time.time() - t0) * 1000),
+                    )
 
         attempts = 0
         while attempts < max_recoveries:

--- a/src/sts2_autotest/core/orchestrator.py
+++ b/src/sts2_autotest/core/orchestrator.py
@@ -3,6 +3,7 @@
 import asyncio
 import json
 import signal
+import time
 from collections.abc import Callable
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -24,6 +25,7 @@ from sts2_autotest.core.recovery import (
     FailureRecord,
     RecoveryAction,
     RecoveryStrategy,
+    _abandon_confirm_action,
     crash_signature,
     failure_signature,
     is_p0_exception,
@@ -33,6 +35,9 @@ from sts2_autotest.core.steam import SteamController
 from sts2_autotest.core.watchdog import Watchdog
 
 logger = get_logger("core.orchestrator")
+
+# 游戏内「放弃」回主菜单的轮询上限（秒）。放弃→死亡/确认→主菜单通常数秒完成。
+_AUTO_RESET_ABANDON_TIMEOUT = 30.0
 
 
 def _is_transient_validation_violation(violations: list[str]) -> bool:
@@ -256,9 +261,12 @@ class TestOrchestrator:
             if screen == GameScreen.MAIN_MENU:
                 return
 
-            # MAP during an active run cannot soft-navigate to MAIN_MENU;
-            # skip directly to hard reset to avoid wasting time in loops.
+            # 进行中的一局本可用游戏内「放弃」（系统设置→放弃游戏→确认）回到
+            # 主菜单，不必硬重启整个游戏进程。先尝试放弃；成功（回到主菜单）则
+            # 继续循环等待；超时/失败才落入 Phase 2 硬重启兜底。
             if screen in {GameScreen.MAP, GameScreen.COMBAT}:
+                if await self._try_abandon_to_main_menu():
+                    continue
                 break
 
             try:
@@ -355,6 +363,37 @@ class TestOrchestrator:
                         continue
             except Exception as exc:
                 logger.warning("Game restart failed: %s", exc)
+
+    async def _try_abandon_to_main_menu(self) -> bool:
+        """尝试用游戏内「放弃」回到主菜单，避免硬重启游戏进程（Q9）。
+
+        对应玩家手动路径：系统设置 → 放弃游戏 → 确认。成功到达 MAIN_MENU 返回
+        True；任意一步失败/超时返回 False，调用方回退到 Phase 2 硬重启兜底。
+        """
+        try:
+            await self.adapter.act("abandon_run")
+        except STS2Error:
+            return False
+        deadline = time.monotonic() + _AUTO_RESET_ABANDON_TIMEOUT
+        while time.monotonic() < deadline:
+            try:
+                state = await self.adapter.get_state()
+            except STS2Error:
+                return False
+            if state.screen == GameScreen.MAIN_MENU:
+                return True
+            try:
+                actions = await self.adapter.get_available_actions()
+            except STS2Error:
+                actions = []
+            confirm = _abandon_confirm_action(actions)
+            if confirm is not None:
+                try:
+                    await self.adapter.act(confirm)
+                except STS2Error:
+                    pass
+            await asyncio.sleep(1.0)
+        return False
 
     async def _record_adapter_result(self, success: bool) -> None:
         """Track adapter call success/failure for degradation detection."""
@@ -484,8 +523,8 @@ class TestOrchestrator:
                     # After abandon_run there may be a confirmation modal
                     try:
                         post_abandon_actions = await self.adapter.get_available_actions()
-                        if "confirm_modal" in post_abandon_actions or "dismiss_modal" in post_abandon_actions:
-                            modal_action = "confirm_modal" if "confirm_modal" in post_abandon_actions else "dismiss_modal"
+                        modal_action = _abandon_confirm_action(list(post_abandon_actions))
+                        if modal_action is not None:
                             logger.info("Modal detected after abandon_run — dismissing via %s", modal_action)
                             await self.adapter.act(modal_action)
                     except Exception:

--- a/src/sts2_autotest/core/recovery.py
+++ b/src/sts2_autotest/core/recovery.py
@@ -6,6 +6,8 @@ DefaultRecoveryStrategy: pure-function decide() + async execute().
 
 from __future__ import annotations
 
+import asyncio
+import time
 from collections.abc import Callable
 from dataclasses import dataclass
 from enum import StrEnum
@@ -109,6 +111,72 @@ def is_p0_exception(exc: Exception) -> bool:
             sub_type = str(detail.get("sub_type", ""))
             if sub_type == "version_mismatch":
                 return True
+    return False
+
+
+def _state_info(adapter_state: Any) -> tuple[str, list[str]]:
+    """Extract (upper-cased screen, available_actions list) from an adapter state."""
+    model_dump = getattr(adapter_state, "model_dump", None)
+    if callable(model_dump) and not asyncio.iscoroutinefunction(model_dump):
+        try:
+            payload = model_dump()
+        except Exception:
+            payload = None
+        if isinstance(payload, dict):
+            acts = payload.get("available_actions") or []
+            return str(payload.get("screen") or "").upper(), list(acts) if acts else []
+    if isinstance(adapter_state, dict):
+        acts = adapter_state.get("available_actions") or []
+        return str(adapter_state.get("screen") or "").upper(), list(acts) if acts else []
+    return "", []
+
+
+def _abandon_confirm_action(actions: list[str]) -> str | None:
+    """放弃后的确认框动作，与 ``start_session`` 的 modal 处理对齐。"""
+    if "confirm_modal" in actions:
+        return "confirm_modal"
+    if "dismiss_modal" in actions:
+        return "dismiss_modal"
+    return None
+
+
+async def _try_soft_reset_to_main_menu(adapter: GameAdapterProtocol) -> bool:
+    """尝试用游戏内「放弃」回到主菜单，避免硬重启进程（Q10 缓冲）。
+
+    仅在游戏仍可控制、且一局进行中时尝试。任何失败（含游戏已不可控的真崩溃）
+    都返回 False，由调用方正常硬重启。成功回到主菜单返回 True。
+    """
+    try:
+        state = await adapter.get_state()
+    except Exception:
+        return False
+    screen, _ = _state_info(state)
+    # 仅在确有进行中的一局时尝试游戏内放弃；干净主菜单不需要。
+    if screen not in (
+        "MAP", "COMBAT", "EVENT", "SHOP", "REST", "CHEST",
+        "CARD_REWARD", "BOSS_REWARD",
+    ):
+        return False
+    try:
+        await adapter.act("abandon_run")
+    except Exception:
+        return False
+    deadline = time.monotonic() + 30.0
+    while time.monotonic() < deadline:
+        try:
+            st = await adapter.get_state()
+        except Exception:
+            return False
+        sc, acts = _state_info(st)
+        if sc == "MAIN_MENU":
+            return True
+        confirm = _abandon_confirm_action(acts)
+        if confirm is not None:
+            try:
+                await adapter.act(confirm)
+            except Exception:
+                pass
+        await asyncio.sleep(1.0)
     return False
 
 
@@ -398,6 +466,12 @@ class DefaultRecoveryStrategy:
         """Level 1: restart game → recreate adapter → health check."""
         if not self._prepare_restart_popup("GAME_RESTART"):
             return False, None
+        # 缓冲（Q10）：游戏仍可控制且一局进行中时，优先用游戏内「放弃」回到主菜单，
+        # 而非硬杀进程重启。可避免把「误诊的崩溃/仍在启动」当成真崩溃而重启游戏。
+        # 仅当游戏确不可控（真崩溃）时 get_state/act 失败，本缓冲返回 False，
+        # 正常落入下面的硬重启。绝不掩盖真崩溃。
+        if await _try_soft_reset_to_main_menu(adapter):
+            return await self._execute_recreate(adapter)
         if self._lifecycle_manager is not None:
             try:
                 if await self._lifecycle_manager.relaunch_run(

--- a/src/sts2_autotest/core/test_agent_runner.py
+++ b/src/sts2_autotest/core/test_agent_runner.py
@@ -193,7 +193,7 @@ def _select_macos_window(
 def _find_macos_window(window_title: str) -> tuple[int, tuple[int, int]] | None:
     """Return the best matching macOS on-screen window id and size."""
     try:
-        import Quartz  # type: ignore[import-untyped]
+        import Quartz  # type: ignore[import-not-found]
     except Exception:
         return None
 
@@ -221,7 +221,7 @@ def _capture_macos_window_png(path: Path, window_title: str) -> bool:
     """Capture a specific macOS window directly into a PNG file."""
     try:
         import Quartz
-        from AppKit import (  # type: ignore[import-untyped]
+        from AppKit import (  # type: ignore[import-not-found]
             NSBitmapImageRep,
             NSPNGFileType,
         )

--- a/src/sts2_autotest/core/test_agent_runner.py
+++ b/src/sts2_autotest/core/test_agent_runner.py
@@ -193,7 +193,7 @@ def _select_macos_window(
 def _find_macos_window(window_title: str) -> tuple[int, tuple[int, int]] | None:
     """Return the best matching macOS on-screen window id and size."""
     try:
-        import Quartz  # type: ignore[import-not-found]
+        import Quartz  # type: ignore[import-untyped]
     except Exception:
         return None
 
@@ -221,7 +221,7 @@ def _capture_macos_window_png(path: Path, window_title: str) -> bool:
     """Capture a specific macOS window directly into a PNG file."""
     try:
         import Quartz
-        from AppKit import (  # type: ignore[import-not-found]
+        from AppKit import (  # type: ignore[import-untyped]
             NSBitmapImageRep,
             NSPNGFileType,
         )

--- a/tests/unit/test_lifecycle.py
+++ b/tests/unit/test_lifecycle.py
@@ -388,7 +388,9 @@ class TestEnsureEnvironmentReady:
         assert mgr._term_calls == 0
         assert "launch" in res.actions_taken
 
-    def test_stale_process_terminates_then_launches(self, monkeypatch):
+    def test_boot_grace_keeps_present_process_when_it_becomes_ready(self, monkeypatch):
+        """Q10 启动宽限期：进程在、但仍在启动（探测先坏后好）时，先等其可控，
+        不应当作崩溃 terminate。"""
         bad = (False, EnvironmentBlockReason.GAME_CONTROL_UNAVAILABLE, {})
         good = (True, None, {"screen": "MAIN_MENU"})
         mgr = self._mgr_with(
@@ -396,6 +398,22 @@ class TestEnsureEnvironmentReady:
         )
         res = asyncio.run(mgr.ensure_environment_ready())
         assert res.ready is True
+        assert mgr._term_calls == 0
+        assert mgr._launch_calls == 0
+        assert res.recovered is False
+
+    def test_present_process_never_ready_is_terminated_then_relaunched(self, monkeypatch, no_sleep):
+        """启动宽限期耗尽（确属坏掉）后，仍按原契约 terminate+单次重拉。"""
+        bad = (False, EnvironmentBlockReason.GAME_CONTROL_UNAVAILABLE, {})
+        mgr = self._mgr_with(
+            monkeypatch, probe_results=[bad, bad, bad, bad, bad, bad], process_present=True
+        )
+        # 缩小启动窗口并跳过进程消失等待，避免长耗时。
+        mgr.api_timeout = 0.05
+        mgr.poll_interval = 0.001
+        monkeypatch.setattr(mgr, "_wait_game_gone", lambda *a, **k: True)
+        res = asyncio.run(mgr.ensure_environment_ready())
+        assert res.ready is False
         assert mgr._term_calls == 1
         assert mgr._launch_calls == 1
         assert res.actions_taken.index("controlled_terminate") < res.actions_taken.index("launch")

--- a/tests/unit/test_orchestrator.py
+++ b/tests/unit/test_orchestrator.py
@@ -25,6 +25,33 @@ def _run(coro: Any) -> Any:
     return asyncio.run(coro)
 
 
+async def _no_sleep(*a, **k):
+    return None
+
+
+def _advance_abandon_clock(monkeypatch: pytest.MonkeyPatch) -> None:
+    """推进 recovery/orchestrator 的放弃轮询时钟，避免单测空等 30s。"""
+    clock = {"now": 0.0}
+
+    def _monotonic() -> float:
+        return clock["now"]
+
+    async def _sleep(seconds: float, *_a: Any, **_k: Any) -> None:
+        clock["now"] += float(seconds)
+
+    monkeypatch.setattr("sts2_autotest.core.recovery.time.monotonic", _monotonic)
+    monkeypatch.setattr("sts2_autotest.core.orchestrator.time.monotonic", _monotonic)
+    monkeypatch.setattr("asyncio.sleep", _sleep)
+
+
+def _fake_steam() -> MagicMock:
+    """硬重启兜底路径用的假 Steam，避免单测真去 ``start_game`` 空等 60s。"""
+    steam = MagicMock()
+    steam.game_exe = "FakeSTS2GameExeForTests.exe"
+    steam.start_game = MagicMock(return_value=4242)
+    return steam
+
+
 def _make_mock_adapter(
     healthy: bool = True,
     screen: GameScreen = GameScreen.MAIN_MENU,
@@ -426,7 +453,9 @@ class TestCrashHandling:
         result = _run(orch.execute_case("TC-001"))
         assert result.status == "crash"
 
-    def test_crash_goes_through_recovery_not_immediate_terminate(self) -> None:
+    def test_crash_goes_through_recovery_not_immediate_terminate(
+        self, monkeypatch
+    ) -> None:
         """CRASH_ERROR should reach recovery.decide(), not immediately crash.
 
         Beta: crash errors flow through progressive recovery
@@ -435,6 +464,7 @@ class TestCrashHandling:
         """
         from unittest.mock import MagicMock
 
+        _advance_abandon_clock(monkeypatch)
         mock_adapter = MagicMock(spec=GameAdapterProtocol)
         mock_adapter.get_available_actions = AsyncMock(return_value=["probe"])
         mock_adapter.act = AsyncMock(return_value=ActionResult("success", True))
@@ -986,6 +1016,68 @@ class TestAutoReset:
 
         assert result is False
 
+    def test_auto_reset_from_combat_prefers_abandon_run(self, monkeypatch) -> None:
+        """Q9：进行中的一局（COMBAT）先用游戏内放弃回主菜单，而非硬重启。"""
+        monkeypatch.setattr("asyncio.sleep", _no_sleep)
+        mock = MagicMock(spec=GameAdapterProtocol)
+        mock.health_check.return_value = HealthStatus(healthy=True)
+        mock.get_state.side_effect = [
+            GameState(screen=GameScreen.COMBAT),
+            GameState(screen=GameScreen.COMBAT),
+            GameState(screen=GameScreen.MAIN_MENU),
+            GameState(screen=GameScreen.MAIN_MENU),
+        ]
+        mock.get_available_actions.return_value = ["abandon_run"]
+
+        orch = TestOrchestrator(adapter=mock)
+        _run(orch._auto_reset_to_main_menu())
+
+        mock.act.assert_any_call("abandon_run")
+
+    def test_auto_reset_from_combat_falls_back_to_hard_reset_when_abandon_fails(
+        self, monkeypatch
+    ) -> None:
+        """Q9：放弃失败（异常）时仍回退到 Phase 2 硬重启兜底，且不静默吞错。"""
+        monkeypatch.setattr("asyncio.sleep", _no_sleep)
+        mock = MagicMock(spec=GameAdapterProtocol)
+        mock.health_check.return_value = HealthStatus(healthy=True)
+        mock.get_state.return_value = GameState(screen=GameScreen.COMBAT)
+        mock.get_available_actions.return_value = ["abandon_run"]
+        mock.act.side_effect = STS2Error(category=ErrorCategory.ADAPTER_ERROR, message="boom")
+        steam = _fake_steam()
+
+        orch = TestOrchestrator(
+            adapter=mock,
+            recovery=DefaultRecoveryStrategy(steam_controller=steam),
+        )
+        _run(orch._auto_reset_to_main_menu())
+
+        mock.act.assert_any_call("abandon_run")
+        steam.start_game.assert_called_once()
+
+    def test_try_abandon_uses_dismiss_modal_when_confirm_absent(
+        self, monkeypatch
+    ) -> None:
+        """放弃确认框若只暴露 dismiss_modal，应与 start_session 一样点掉后回到主菜单。"""
+        monkeypatch.setattr("asyncio.sleep", _no_sleep)
+        monkeypatch.setattr(
+            "sts2_autotest.core.orchestrator._AUTO_RESET_ABANDON_TIMEOUT", 0.05
+        )
+        mock = MagicMock(spec=GameAdapterProtocol)
+        mock.get_state.side_effect = [
+            GameState(screen=GameScreen.COMBAT),
+            GameState(screen=GameScreen.MAIN_MENU),
+        ]
+        mock.get_available_actions.return_value = ["dismiss_modal"]
+        mock.act.return_value = ActionResult(status="success", state_changed=True)
+
+        orch = TestOrchestrator(adapter=mock)
+        result = _run(orch._try_abandon_to_main_menu())
+
+        assert result is True
+        mock.act.assert_any_call("abandon_run")
+        mock.act.assert_any_call("dismiss_modal")
+
     def test_auto_reset_success_returns_true(self) -> None:
         """Auto-reset reaches MAIN_MENU → session starts successfully."""
         call_count = 0
@@ -1008,22 +1100,27 @@ class TestAutoReset:
         assert result is True
         assert orch._session_active is True
 
-    def test_auto_reset_combat_skips_soft_nav(self) -> None:
-        """COMBAT state skips soft navigation and goes directly to hard reset."""
-        states = [GameState(screen=GameScreen.COMBAT)] * 10
-        idx = 0
-
-        def state_factory() -> GameState:
-            nonlocal idx
-            s = states[min(idx, len(states) - 1)]
-            idx += 1
-            return s
-
+    def test_auto_reset_combat_falls_back_when_abandon_does_not_reach_menu(
+        self, monkeypatch
+    ) -> None:
+        """COMBAT 放弃后仍停在战斗时，回退硬重启；硬重启失败则会话启动失败。"""
+        monkeypatch.setattr("asyncio.sleep", _no_sleep)
+        monkeypatch.setattr(
+            "sts2_autotest.core.orchestrator._AUTO_RESET_ABANDON_TIMEOUT", 0.0
+        )
         mock = MagicMock(spec=GameAdapterProtocol)
         mock.health_check.return_value = HealthStatus(healthy=True)
-        mock.get_state.side_effect = state_factory
+        mock.get_state.return_value = GameState(screen=GameScreen.COMBAT)
         mock.get_available_actions.return_value = ["probe"]
+        mock.act.side_effect = STS2Error(
+            category=ErrorCategory.ADAPTER_ERROR, message="abandon unavailable"
+        )
+        steam = _fake_steam()
 
-        orch = TestOrchestrator(adapter=mock)
+        orch = TestOrchestrator(
+            adapter=mock,
+            recovery=DefaultRecoveryStrategy(steam_controller=steam),
+        )
         result = _run(orch.start_session())
         assert result is False
+        steam.start_game.assert_called_once()

--- a/tests/unit/test_recovery_strategy.py
+++ b/tests/unit/test_recovery_strategy.py
@@ -6,14 +6,16 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
-from sts2_autotest.adapters.base import HealthStatus
+from sts2_autotest.adapters.base import ActionResult, HealthStatus
 from sts2_autotest.common.errors import ErrorCategory, STS2Error
+from sts2_autotest.common.state import GameScreen, GameState
 from sts2_autotest.core.popup_disposal import PopupDisposition
 from sts2_autotest.core.recovery import (
     DefaultRecoveryStrategy,
     FailureRecord,
     RecoveryAction,
     StubRecoveryStrategy,
+    _try_soft_reset_to_main_menu,
     crash_signature,
     is_p0_exception,
 )
@@ -583,6 +585,134 @@ class TestExecuteGameRestart:
         assert success is False
         assert result_adapter is None
         popup_handler.assert_called_once()
+        mock_steam.restart_game.assert_not_called()
+
+
+async def _no_sleep(*_a: Any, **_k: Any) -> None:
+    return None
+
+
+def _advance_clock(monkeypatch: pytest.MonkeyPatch, module: str) -> None:
+    """让软放弃轮询不空等墙钟：sleep 推进 monotonic。"""
+    clock = {"now": 0.0}
+
+    def _monotonic() -> float:
+        return clock["now"]
+
+    async def _sleep(seconds: float, *_a: Any, **_k: Any) -> None:
+        clock["now"] += float(seconds)
+
+    monkeypatch.setattr(f"{module}.time.monotonic", _monotonic)
+    monkeypatch.setattr("asyncio.sleep", _sleep)
+
+
+class TestTrySoftResetToMainMenu:
+    """Q10：GAME_RESTART 前的游戏内放弃缓冲。"""
+
+    def test_skips_when_already_at_main_menu(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        _advance_clock(monkeypatch, "sts2_autotest.core.recovery")
+        adapter = AsyncMock()
+        adapter.get_state.return_value = GameState(screen=GameScreen.MAIN_MENU)
+
+        ok = _run(_try_soft_reset_to_main_menu(adapter))
+
+        assert ok is False
+        adapter.act.assert_not_awaited()
+
+    def test_skips_when_get_state_fails(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        _advance_clock(monkeypatch, "sts2_autotest.core.recovery")
+        adapter = AsyncMock()
+        adapter.get_state.side_effect = RuntimeError("dead")
+
+        ok = _run(_try_soft_reset_to_main_menu(adapter))
+
+        assert ok is False
+        adapter.act.assert_not_awaited()
+
+    def test_combat_abandon_reaches_main_menu(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        _advance_clock(monkeypatch, "sts2_autotest.core.recovery")
+        adapter = AsyncMock()
+        adapter.get_state.side_effect = [
+            GameState(screen=GameScreen.COMBAT),
+            GameState(screen=GameScreen.MAIN_MENU),
+        ]
+        adapter.act.return_value = ActionResult(status="success", state_changed=True)
+
+        ok = _run(_try_soft_reset_to_main_menu(adapter))
+
+        assert ok is True
+        adapter.act.assert_any_await("abandon_run")
+
+    def test_uses_dismiss_modal_when_confirm_absent(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """确认框若只暴露 dismiss_modal（与 start_session 对齐），仍应点掉后回到主菜单。"""
+        _advance_clock(monkeypatch, "sts2_autotest.core.recovery")
+        adapter = AsyncMock()
+        adapter.get_state.side_effect = [
+            GameState(screen=GameScreen.MAP),
+            GameState(
+                screen=GameScreen.MAP,
+                available_actions=["dismiss_modal"],
+            ),
+            GameState(screen=GameScreen.MAIN_MENU),
+        ]
+        adapter.act.return_value = ActionResult(status="success", state_changed=True)
+
+        ok = _run(_try_soft_reset_to_main_menu(adapter))
+
+        assert ok is True
+        adapter.act.assert_any_await("abandon_run")
+        adapter.act.assert_any_await("dismiss_modal")
+
+    def test_abandon_failure_does_not_mask_crash(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        _advance_clock(monkeypatch, "sts2_autotest.core.recovery")
+        adapter = AsyncMock()
+        adapter.get_state.return_value = GameState(screen=GameScreen.COMBAT)
+        adapter.act.side_effect = RuntimeError("uncontrollable")
+
+        ok = _run(_try_soft_reset_to_main_menu(adapter))
+
+        assert ok is False
+
+
+class TestExecuteGameRestartSoftBuffer:
+    """GAME_RESTART 在硬杀进程前优先走软放弃。"""
+
+    @staticmethod
+    def _make_healthy_adapter() -> Any:
+        adapter = AsyncMock()
+        adapter.health_check.return_value = HealthStatus(healthy=True)
+        adapter.cleanup.return_value = None
+        return adapter
+
+    def test_soft_reset_success_skips_steam_restart(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        _advance_clock(monkeypatch, "sts2_autotest.core.recovery")
+        mock_steam = MagicMock()
+        mock_steam.restart_game = MagicMock(return_value=12345)
+        new_adapter = self._make_healthy_adapter()
+        old_adapter = self._make_healthy_adapter()
+        old_adapter.get_state.side_effect = [
+            GameState(screen=GameScreen.MAP),
+            GameState(screen=GameScreen.MAIN_MENU),
+        ]
+        old_adapter.act.return_value = ActionResult(status="success", state_changed=True)
+        strategy = DefaultRecoveryStrategy(
+            adapter_factory=lambda: new_adapter,
+            steam_controller=mock_steam,
+        )
+
+        success, result_adapter = _run(
+            strategy.execute(RecoveryAction.GAME_RESTART, old_adapter)
+        )
+
+        assert success is True
+        assert result_adapter is new_adapter
+        old_adapter.act.assert_any_await("abandon_run")
         mock_steam.restart_game.assert_not_called()
 
 


### PR DESCRIPTION
ensure_environment_ready 不再把仍在启动的游戏判为陈旧进程立刻重拉；
mid-run / GAME_RESTART 先走 abandon_run（含 dismiss_modal 对齐），硬重启仅作兜底。