### PR TITLE
feat(ci): workflow upload-artifact 步骤顺序静态校验门禁（issue #51）

### DIFF
--- a/.github/scripts/check_workflow_artifact_order.py
+++ b/.github/scripts/check_workflow_artifact_order.py
@@ -1,0 +1,293 @@
+#!/usr/bin/env python3
+"""静态校验 GitHub Actions workflow 中 upload-artifact 与 producer 步骤顺序（issue #51）。
+
+规则：manifest 声明的 artifact 路径，凡被 upload-artifact 引用，其上传步骤在
+同一 job 的 steps 数组中必须出现在所有 producer 步骤之后。
+"""
+
+from __future__ import annotations
+
+import argparse
+import fnmatch
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+DEFAULT_MANIFEST = Path(".github/workflow-artifact-manifest.yaml")
+DEFAULT_WORKFLOWS_DIR = Path(".github/workflows")
+
+
+@dataclass(frozen=True)
+class StepRef:
+    """Job 内步骤引用。"""
+
+    index: int
+    step_id: str | None
+    name: str | None
+
+    @property
+    def label(self) -> str:
+        if self.step_id:
+            return f"id={self.step_id!r}"
+        if self.name:
+            return f"name={self.name!r}"
+        return f"index={self.index}"
+
+
+@dataclass(frozen=True)
+class Violation:
+    workflow_file: str
+    job_id: str
+    artifact: str
+    upload: StepRef
+    producer: StepRef
+    message: str
+
+
+def _load_yaml(path: Path) -> Any:
+    with path.open(encoding="utf-8") as handle:
+        return yaml.safe_load(handle)
+
+
+def _step_ref(index: int, step: dict[str, Any]) -> StepRef:
+    raw_id = step.get("id")
+    raw_name = step.get("name")
+    step_id = raw_id if isinstance(raw_id, str) and raw_id else None
+    name = raw_name if isinstance(raw_name, str) and raw_name else None
+    return StepRef(index=index, step_id=step_id, name=name)
+
+
+def _is_upload_artifact_step(step: dict[str, Any]) -> bool:
+    uses = step.get("uses")
+    return isinstance(uses, str) and "upload-artifact" in uses
+
+
+def _upload_paths(step: dict[str, Any]) -> list[str]:
+    with_block = step.get("with")
+    if not isinstance(with_block, dict):
+        return []
+    path_value = with_block.get("path")
+    if not isinstance(path_value, str):
+        return []
+    return [line.strip() for line in path_value.splitlines() if line.strip()]
+
+
+def _path_matches(upload_pattern: str, artifact: str) -> bool:
+    if upload_pattern == artifact:
+        return True
+    if any(ch in upload_pattern for ch in "*?[]"):
+        return fnmatch.fnmatch(artifact, upload_pattern)
+    return False
+
+
+def _upload_references_artifact(step: dict[str, Any], artifact: str) -> bool:
+    return any(_path_matches(path, artifact) for path in _upload_paths(step))
+
+
+def _find_producer_indices(
+    steps: list[dict[str, Any]],
+    producers: list[dict[str, str]],
+) -> list[StepRef]:
+    found: list[StepRef] = []
+    for index, step in enumerate(steps):
+        ref = _step_ref(index, step)
+        for producer in producers:
+            pid = producer.get("id")
+            pname = producer.get("name")
+            if pid and ref.step_id == pid:
+                found.append(ref)
+                break
+            if pname and ref.name == pname:
+                found.append(ref)
+                break
+    return found
+
+
+def _find_upload_indices(steps: list[dict[str, Any]], artifact: str) -> list[StepRef]:
+    uploads: list[StepRef] = []
+    for index, step in enumerate(steps):
+        if _is_upload_artifact_step(step) and _upload_references_artifact(step, artifact):
+            uploads.append(_step_ref(index, step))
+    return uploads
+
+
+def _validate_job_rules(
+    workflow_file: str,
+    job_id: str,
+    steps: list[dict[str, Any]],
+    rules: list[dict[str, Any]],
+) -> list[Violation]:
+    violations: list[Violation] = []
+
+    for rule in rules:
+        artifact = rule.get("artifact")
+        producers_cfg = rule.get("producers")
+        if not isinstance(artifact, str) or not isinstance(producers_cfg, list):
+            continue
+
+        producer_refs = _find_producer_indices(steps, producers_cfg)
+        if not producer_refs:
+            producer_desc = ", ".join(
+                f"id={p.get('id')!r}" if p.get("id") else f"name={p.get('name')!r}"
+                for p in producers_cfg
+                if isinstance(p, dict)
+            )
+            violations.append(
+                Violation(
+                    workflow_file=workflow_file,
+                    job_id=job_id,
+                    artifact=artifact,
+                    upload=StepRef(index=-1, step_id=None, name="(none)"),
+                    producer=StepRef(index=-1, step_id=None, name="(missing)"),
+                    message=(
+                        f"producer 步骤未找到（{producer_desc}），"
+                        f"无法校验 {artifact!r} 的上传顺序"
+                    ),
+                )
+            )
+            continue
+
+        upload_refs = _find_upload_indices(steps, artifact)
+        if not upload_refs:
+            continue
+
+        latest_producer_index = max(ref.index for ref in producer_refs)
+        latest_producer = next(ref for ref in producer_refs if ref.index == latest_producer_index)
+
+        for upload in upload_refs:
+            if upload.index <= latest_producer_index:
+                violations.append(
+                    Violation(
+                        workflow_file=workflow_file,
+                        job_id=job_id,
+                        artifact=artifact,
+                        upload=upload,
+                        producer=latest_producer,
+                        message=(
+                            f"upload 步骤 ({upload.label}, index={upload.index}) "
+                            f"必须晚于 producer 步骤 ({latest_producer.label}, "
+                            f"index={latest_producer_index})"
+                        ),
+                    )
+                )
+
+    return violations
+
+
+def validate_manifest(
+    manifest_path: Path,
+    workflows_dir: Path,
+) -> list[Violation]:
+    manifest = _load_yaml(manifest_path)
+    if not isinstance(manifest, dict):
+        raise ValueError(f"manifest 根节点必须是 mapping：{manifest_path}")
+
+    workflow_rules = manifest.get("workflows")
+    if not isinstance(workflow_rules, list):
+        raise ValueError(f"manifest 缺少 workflows 列表：{manifest_path}")
+
+    all_violations: list[Violation] = []
+
+    for entry in workflow_rules:
+        if not isinstance(entry, dict):
+            continue
+        file_name = entry.get("file")
+        job_filter = entry.get("job")
+        rules = entry.get("rules")
+        if not isinstance(file_name, str) or not isinstance(rules, list):
+            continue
+
+        workflow_path = workflows_dir / file_name
+        if not workflow_path.is_file():
+            all_violations.append(
+                Violation(
+                    workflow_file=file_name,
+                    job_id=str(job_filter or "*"),
+                    artifact="*",
+                    upload=StepRef(index=-1, step_id=None, name="(none)"),
+                    producer=StepRef(index=-1, step_id=None, name="(missing)"),
+                    message=f"workflow 文件不存在：{workflow_path}",
+                )
+            )
+            continue
+
+        workflow = _load_yaml(workflow_path)
+        if not isinstance(workflow, dict):
+            continue
+        jobs = workflow.get("jobs")
+        if not isinstance(jobs, dict):
+            continue
+
+        for job_id, job in jobs.items():
+            if job_filter is not None and job_id != job_filter:
+                continue
+            if not isinstance(job, dict):
+                continue
+            steps = job.get("steps")
+            if not isinstance(steps, list):
+                continue
+            step_dicts = [step for step in steps if isinstance(step, dict)]
+            all_violations.extend(
+                _validate_job_rules(file_name, job_id, step_dicts, rules)
+            )
+
+    return all_violations
+
+
+def _print_violations(violations: list[Violation]) -> None:
+    for item in violations:
+        print(
+            f"::error file=.github/workflows/{item.workflow_file}"
+            f"::[{item.job_id}] {item.artifact}: {item.message}",
+            file=sys.stderr,
+        )
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="校验 workflow 中 upload-artifact 步骤必须晚于 producer 步骤",
+    )
+    parser.add_argument(
+        "--manifest",
+        type=Path,
+        default=DEFAULT_MANIFEST,
+        help="artifact↔producer 映射 manifest（默认 .github/workflow-artifact-manifest.yaml）",
+    )
+    parser.add_argument(
+        "--workflows-dir",
+        type=Path,
+        default=DEFAULT_WORKFLOWS_DIR,
+        help="workflow YAML 目录（默认 .github/workflows）",
+    )
+    args = parser.parse_args(argv)
+
+    manifest_path = args.manifest.resolve()
+    workflows_dir = args.workflows_dir.resolve()
+
+    if not manifest_path.is_file():
+        print(f"::error::manifest 不存在：{manifest_path}", file=sys.stderr)
+        return 2
+
+    try:
+        violations = validate_manifest(manifest_path, workflows_dir)
+    except ValueError as exc:
+        print(f"::error::{exc}", file=sys.stderr)
+        return 2
+
+    if violations:
+        _print_violations(violations)
+        print(
+            f"workflow artifact order check FAILED: {len(violations)} violation(s)",
+            file=sys.stderr,
+        )
+        return 1
+
+    print("workflow artifact order check PASSED")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/workflow-artifact-manifest.yaml
+++ b/.github/workflow-artifact-manifest.yaml
@@ -1,0 +1,28 @@
+# upload-artifact 与 producer 步骤顺序声明（issue #51）
+# 校验器：.github/scripts/check_workflow_artifact_order.py
+#
+# 规则：同一 job 内，引用 artifact 路径的 upload-artifact 步骤下标必须严格大于
+# 所有列出的 producer 步骤下标。
+
+workflows:
+  - file: ci-pr.yml
+    job: validation
+    rules:
+      - artifact: ruff-check.log
+        producers:
+          - id: ruff
+      - artifact: pytest-check.log
+        producers:
+          - id: unit
+      - artifact: mypy-check.log
+        producers:
+          - id: mypy
+      - artifact: timeout-demo.log
+        producers:
+          - id: timeout_demo
+      - artifact: junit-unit.xml
+        producers:
+          - id: unit
+      - artifact: junit-integration.xml
+        producers:
+          - id: cli_tests

--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -202,6 +202,12 @@ jobs:
             pytest-check.log
             timeout-demo.log
 
+      - name: Check workflow artifact step order (issue-51)
+        # 静态校验 upload-artifact 必须晚于 manifest 声明的 producer 步骤；乱序则 fail-closed。
+        id: workflow_artifact_order
+        if: always() && steps.install.outcome == 'success'
+        run: .venv-ci/bin/python .github/scripts/check_workflow_artifact_order.py
+
       - name: Generate summary
         if: always()
         run: |
@@ -276,5 +282,6 @@ jobs:
           check_timeout "Unit tests" "${{ steps.unit.outcome }}" "${{ steps.unit.outputs.timeout }}"
           check "Real STS2 CLI discovery" "${{ steps.cli_check.outcome }}"
           check "CLI integration" "${{ steps.cli_tests.outcome }}"
+          check "Workflow artifact order" "${{ steps.workflow_artifact_order.outcome }}"
 
           exit "$failed"

--- a/tests/unit/test_ci_workflow_artifact_order.py
+++ b/tests/unit/test_ci_workflow_artifact_order.py
@@ -1,0 +1,224 @@
+"""check_workflow_artifact_order.py 单元测试（issue #51）。"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+import yaml
+
+_SCRIPTS_DIR = Path(__file__).resolve().parents[2] / ".github" / "scripts"
+_SPEC = importlib.util.spec_from_file_location(
+    "check_workflow_artifact_order_script",
+    _SCRIPTS_DIR / "check_workflow_artifact_order.py",
+)
+assert _SPEC and _SPEC.loader
+check_module = importlib.util.module_from_spec(_SPEC)
+sys.modules[_SPEC.name] = check_module
+_SPEC.loader.exec_module(check_module)
+
+validate_manifest = check_module.validate_manifest
+main = check_module.main
+
+
+def _write_workflow(tmp_path: Path, content: dict) -> Path:
+    workflows_dir = tmp_path / "workflows"
+    workflows_dir.mkdir(parents=True)
+    path = workflows_dir / "sample.yml"
+    path.write_text(yaml.dump(content), encoding="utf-8")
+    return workflows_dir
+
+
+def _write_manifest(
+    tmp_path: Path,
+    *,
+    workflow_file: str,
+    job: str,
+    artifact: str,
+    producer_id: str,
+) -> Path:
+    manifest = {
+        "workflows": [
+            {
+                "file": workflow_file,
+                "job": job,
+                "rules": [
+                    {
+                        "artifact": artifact,
+                        "producers": [{"id": producer_id}],
+                    }
+                ],
+            }
+        ]
+    }
+    manifest_path = tmp_path / "manifest.yaml"
+    manifest_path.write_text(yaml.dump(manifest), encoding="utf-8")
+    return manifest_path
+
+
+def test_pass_when_upload_after_producer(tmp_path: Path) -> None:
+    workflows_dir = _write_workflow(
+        tmp_path,
+        {
+            "jobs": {
+                "validation": {
+                    "steps": [
+                        {"id": "mypy", "name": "Check no new mypy debt", "run": "echo mypy"},
+                        {
+                            "name": "Upload check logs",
+                            "uses": "actions/upload-artifact@v4",
+                            "with": {"path": "mypy-check.log"},
+                        },
+                    ]
+                }
+            }
+        },
+    )
+    manifest_path = _write_manifest(
+        tmp_path,
+        workflow_file="sample.yml",
+        job="validation",
+        artifact="mypy-check.log",
+        producer_id="mypy",
+    )
+
+    violations = validate_manifest(manifest_path, workflows_dir)
+    assert violations == []
+
+
+def test_fail_when_upload_before_producer(tmp_path: Path) -> None:
+    workflows_dir = _write_workflow(
+        tmp_path,
+        {
+            "jobs": {
+                "validation": {
+                    "steps": [
+                        {
+                            "name": "Upload check logs",
+                            "uses": "actions/upload-artifact@v4",
+                            "with": {"path": "mypy-check.log"},
+                        },
+                        {"id": "mypy", "name": "Check no new mypy debt", "run": "echo mypy"},
+                    ]
+                }
+            }
+        },
+    )
+    manifest_path = _write_manifest(
+        tmp_path,
+        workflow_file="sample.yml",
+        job="validation",
+        artifact="mypy-check.log",
+        producer_id="mypy",
+    )
+
+    violations = validate_manifest(manifest_path, workflows_dir)
+    assert len(violations) == 1
+    assert violations[0].artifact == "mypy-check.log"
+    assert violations[0].upload.index == 0
+    assert violations[0].producer.index == 1
+
+
+def test_multiline_upload_path_matches_artifact(tmp_path: Path) -> None:
+    workflows_dir = _write_workflow(
+        tmp_path,
+        {
+            "jobs": {
+                "validation": {
+                    "steps": [
+                        {"id": "mypy", "run": "echo"},
+                        {
+                            "uses": "actions/upload-artifact@v4",
+                            "with": {
+                                "path": "ruff-check.log\nmypy-check.log\npytest-check.log",
+                            },
+                        },
+                    ]
+                }
+            }
+        },
+    )
+    manifest_path = _write_manifest(
+        tmp_path,
+        workflow_file="sample.yml",
+        job="validation",
+        artifact="mypy-check.log",
+        producer_id="mypy",
+    )
+
+    assert validate_manifest(manifest_path, workflows_dir) == []
+
+
+def test_fail_closed_when_producer_missing(tmp_path: Path) -> None:
+    workflows_dir = _write_workflow(
+        tmp_path,
+        {
+            "jobs": {
+                "validation": {
+                    "steps": [
+                        {
+                            "uses": "actions/upload-artifact@v4",
+                            "with": {"path": "mypy-check.log"},
+                        },
+                    ]
+                }
+            }
+        },
+    )
+    manifest_path = _write_manifest(
+        tmp_path,
+        workflow_file="sample.yml",
+        job="validation",
+        artifact="mypy-check.log",
+        producer_id="mypy",
+    )
+
+    violations = validate_manifest(manifest_path, workflows_dir)
+    assert len(violations) == 1
+    assert "producer 步骤未找到" in violations[0].message
+
+
+def test_real_ci_pr_yml_passes(repo_root: Path) -> None:
+    manifest_path = repo_root / ".github" / "workflow-artifact-manifest.yaml"
+    workflows_dir = repo_root / ".github" / "workflows"
+    if not manifest_path.is_file():
+        pytest.skip("manifest 尚未合入当前分支")
+
+    violations = validate_manifest(manifest_path, workflows_dir)
+    assert violations == []
+
+
+def test_main_exit_code_on_violation(tmp_path: Path) -> None:
+    workflows_dir = _write_workflow(
+        tmp_path,
+        {
+            "jobs": {
+                "validation": {
+                    "steps": [
+                        {
+                            "uses": "actions/upload-artifact@v4",
+                            "with": {"path": "mypy-check.log"},
+                        },
+                        {"id": "mypy", "run": "echo"},
+                    ]
+                }
+            }
+        },
+    )
+    manifest_path = _write_manifest(
+        tmp_path,
+        workflow_file="sample.yml",
+        job="validation",
+        artifact="mypy-check.log",
+        producer_id="mypy",
+    )
+
+    rc = main(["--manifest", str(manifest_path), "--workflows-dir", str(workflows_dir)])
+    assert rc == 1
+
+
+@pytest.fixture
+def repo_root() -> Path:
+    return Path(__file__).resolve().parents[2]


### PR DESCRIPTION
## Summary

- 新增 `.github/scripts/check_workflow_artifact_order.py` + `.github/workflow-artifact-manifest.yaml`，静态校验 upload-artifact 步骤必须晚于 producer 步骤
- 新增 `tests/unit/test_ci_workflow_artifact_order.py`（6 cases）
- 接入 `ci-pr.yml` PR Check Summary 门禁（`Enforce validation result`）

Fixes #51

## 验收结论

人工验收通过（dev-workflow-2.0 run `.agent-runs/issue-51/`）：
- 乱序 → 单测失败 / exit 1 ✅
- 当前 ci-pr.yml → 脚本 exit 0 ✅
- 单测 6/6 ✅

## 报告清单

- `.agent-runs/issue-51/dev-report.md`
- `.agent-runs/issue-51/test-report.md`
- `.agent-runs/issue-51/review-report.md`
- `.agent-runs/issue-51/acceptance-summary.md`

## 后续（非阻塞）

- 工单 03：扩展 ci-main/ci-nightly/ci-game、verify.sh、治理文档

## Test plan

- [x] `pytest tests/unit/test_ci_workflow_artifact_order.py -q`
- [x] `python .github/scripts/check_workflow_artifact_order.py`
- [ ] PR Check Summary CI 绿

Made with [Cursor](https://cursor.com)