### PR TITLE
feat(ci): 扩展 workflow artifact 顺序校验覆盖面（issue #61）

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -3,6 +3,8 @@
 # 且必须走独立政策变更 PR（.github/PULL_REQUEST_TEMPLATE/policy_change.md）。
 .github/workflows/ @crystepj-max
 .github/scripts/check_*_baseline.py @crystepj-max
+.github/scripts/check_workflow_artifact_order.py @crystepj-max
+.github/workflow-artifact-manifest.yaml @crystepj-max
 .github/pytest-baseline.json @crystepj-max
 .github/requirements-lint.txt @crystepj-max
 .github/mypy-policy.ini @crystepj-max

--- a/.github/workflow-artifact-manifest.yaml
+++ b/.github/workflow-artifact-manifest.yaml
@@ -1,4 +1,4 @@
-# upload-artifact 与 producer 步骤顺序声明（issue #51）
+# upload-artifact 与 producer 步骤顺序声明（issue #51 / #61）
 # 校验器：.github/scripts/check_workflow_artifact_order.py
 #
 # 规则：同一 job 内，引用 artifact 路径的 upload-artifact 步骤下标必须严格大于
@@ -26,3 +26,36 @@ workflows:
       - artifact: junit-integration.xml
         producers:
           - id: cli_tests
+
+  - file: ci-main.yml
+    job: quick-checks
+    rules:
+      - artifact: junit-unit.xml
+        producers:
+          - name: "Run ${{ matrix.check }}"
+
+  - file: ci-nightly.yml
+    job: nightly
+    rules:
+      - artifact: junit-unit.xml
+        producers:
+          - id: unit_tests
+      - artifact: junit-integration.xml
+        producers:
+          - id: cli_tests
+      - artifact: junit-game.xml
+        producers:
+          - id: game_tests
+      - artifact: tests/output/
+        producers:
+          - id: package
+
+  - file: ci-game.yml
+    job: game-test
+    rules:
+      - artifact: junit-game.xml
+        producers:
+          - name: Run game integration tests
+      - artifact: tests/output/
+        producers:
+          - name: Run game integration tests

--- a/docs/process/quality-gate-governance.md
+++ b/docs/process/quality-gate-governance.md
@@ -25,6 +25,8 @@
 - `.github/scripts/check_ruff_baseline.py`
 - `.github/scripts/check_mypy_baseline.py`
 - `.github/scripts/check_pytest_baseline.py`
+- `.github/scripts/check_workflow_artifact_order.py`（issue #51 / #61）
+- `.github/workflow-artifact-manifest.yaml`（issue #51 / #61）
 - `.github/pytest-baseline.json`
 - `.github/requirements-lint.txt`
 - `.github/mypy-policy.ini`
@@ -44,6 +46,7 @@
 3. **mypy 参数固定（决策 03）**：`.github/mypy-policy.ini` 固定 `strict` / `show_error_codes` / `no_error_summary`；`check_mypy_baseline.py --config-file` 显式引用。
 4. **基线独立环境（决策 04）**：CI 为基线创建独立 `.venv-baseline`（安装基线 dev 依赖 + 固定 lint 工具），隔离 PR 依赖变化对比较结果的污染。
 5. **Ruff 规则固定（决策 02）**：无显式配置文件，使用固定版本默认规则集；`ruff.toml` / `.ruff.toml` 路径受保护（新增即触发审批）。
+6. **Workflow artifact 步骤顺序（issue #51 / #61）**：`check_workflow_artifact_order.py` + `workflow-artifact-manifest.yaml` 静态校验 upload-artifact 必须晚于 producer；`ci-pr.yml` 门禁强制，本地 `scripts/verify.sh` 硬门槛同步执行。
 
 ### 3.2 流程层
 
@@ -74,6 +77,7 @@
 | `tests/unit/test_ci_pytest_baseline.py` | `--baseline-json` 从 base 读取；fail-closed；#42 已清偿强制失效 |
 | `tests/unit/test_ci_ruff_baseline.py` | `--ruff-bin` / `--baseline-ruff-bin` 显式路径；相对路径转绝对 |
 | `tests/unit/test_ci_mypy_baseline.py` | `--config-file` / `--mypy-bin` 参数透传 |
+| `tests/unit/test_ci_workflow_artifact_order.py` | upload 晚于 producer；ci-pr/main/nightly/game 真实 YAML 通过 |
 | `tests/unit/test_policy_files.py` | CODEOWNERS 覆盖政策文件清单（防保护被悄然移除） |
 
 ### 真实探针 PR（一次性建立，之后每季度或政策变更后复跑）

--- a/scripts/verify.sh
+++ b/scripts/verify.sh
@@ -2,18 +2,20 @@
 # verify.sh — STS2-AUTOTEST 本地全量验证（issue-24 运行保障任务收口）
 #
 # 硬门槛（必须全绿）：
-#   1. scripts/ 下 shell 脚本测试（runner-ctl / setup-mac-runner / runner-probe / check-runner-health）
-#   2. 单元测试 tests/unit/
-#   3. lint-imports（导入层级隔离）
+#   1. workflow artifact 步骤顺序（issue #61；与 CI check_workflow_artifact_order.py 同语义）
+#   2. scripts/ 下 shell 脚本测试（runner-ctl / setup-mac-runner / runner-probe / check-runner-health）
+#   3. 单元测试 tests/unit/
+#   4. lint-imports（导入层级隔离）
 #
 # 增量门禁（提供 BASELINE_DIR 时执行；缺省跳过，由 CI 兜底）：
-#   4. ruff 无新增债务（与 CI check_ruff_baseline.py 同语义）
-#   5. mypy 无新增债务（与 CI check_mypy_baseline.py 同语义）
+#   5. ruff 无新增债务（与 CI check_ruff_baseline.py 同语义）
+#   6. mypy 无新增债务（与 CI check_mypy_baseline.py 同语义）
 #   —— 仓库存在既有 Ruff/mypy 债务（归属 Issue #25），全量零错误不是当前基线
 #
 # 用法：./scripts/verify.sh [BASELINE_DIR=<main 分支 checkout 路径>]
 # 环境变量：PYTHON 覆盖解释器（默认 .venv/bin/python）、VERIFY_STEP_TIMEOUT
-#          每步超时秒数（默认：shell 测试 600 / 单元测试 1800 / lint-imports 300）
+#          每步超时秒数（默认：shell 测试 600 / 单元测试 1800 / lint-imports 300 /
+#          workflow 顺序校验 60）
 set -uo pipefail
 
 REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
@@ -51,6 +53,8 @@ step() {
 
 cd "$REPO_ROOT"
 
+step "workflow artifact 步骤顺序" "${VERIFY_STEP_TIMEOUT:-60}" \
+    "$PYTHON" .github/scripts/check_workflow_artifact_order.py
 step "shell 脚本测试" "${VERIFY_STEP_TIMEOUT:-600}" bash scripts/tests/run-all.sh
 step "单元测试" "${VERIFY_STEP_TIMEOUT:-1800}" "$PYTHON" -m pytest tests/unit/ -q
 step "lint-imports" "${VERIFY_STEP_TIMEOUT:-300}" "$REPO_ROOT/.venv/bin/lint-imports"

--- a/tests/unit/test_ci_workflow_artifact_order.py
+++ b/tests/unit/test_ci_workflow_artifact_order.py
@@ -190,6 +190,106 @@ def test_real_ci_pr_yml_passes(repo_root: Path) -> None:
     assert violations == []
 
 
+def test_fail_when_upload_before_producer_by_name(tmp_path: Path) -> None:
+    """ci-main 风格：producer 仅有 name（无 id）时，upload 在前必须失败。"""
+    workflows_dir = _write_workflow(
+        tmp_path,
+        {
+            "jobs": {
+                "quick-checks": {
+                    "steps": [
+                        {
+                            "name": "Upload JUnit",
+                            "uses": "actions/upload-artifact@v4",
+                            "with": {"path": "junit-unit.xml"},
+                        },
+                        {
+                            "name": "Run ${{ matrix.check }}",
+                            "run": "echo unit",
+                        },
+                    ]
+                }
+            }
+        },
+    )
+    manifest = {
+        "workflows": [
+            {
+                "file": "sample.yml",
+                "job": "quick-checks",
+                "rules": [
+                    {
+                        "artifact": "junit-unit.xml",
+                        "producers": [{"name": "Run ${{ matrix.check }}"}],
+                    }
+                ],
+            }
+        ]
+    }
+    manifest_path = tmp_path / "manifest.yaml"
+    manifest_path.write_text(yaml.dump(manifest), encoding="utf-8")
+
+    violations = validate_manifest(manifest_path, workflows_dir)
+    assert len(violations) == 1
+    assert violations[0].artifact == "junit-unit.xml"
+    assert violations[0].upload.index < violations[0].producer.index
+
+
+def test_glob_upload_path_requires_all_producers(tmp_path: Path) -> None:
+    """ci-nightly 风格：upload path 为 junit-*.xml 时，须晚于各匹配 artifact 的 producer。"""
+    workflows_dir = _write_workflow(
+        tmp_path,
+        {
+            "jobs": {
+                "nightly": {
+                    "steps": [
+                        {"id": "unit_tests", "run": "echo unit"},
+                        {
+                            "name": "Upload JUnit results",
+                            "uses": "actions/upload-artifact@v4",
+                            "with": {"path": "junit-*.xml"},
+                        },
+                        {"id": "game_tests", "run": "echo game"},
+                    ]
+                }
+            }
+        },
+    )
+    manifest = {
+        "workflows": [
+            {
+                "file": "sample.yml",
+                "job": "nightly",
+                "rules": [
+                    {"artifact": "junit-unit.xml", "producers": [{"id": "unit_tests"}]},
+                    {"artifact": "junit-game.xml", "producers": [{"id": "game_tests"}]},
+                ],
+            }
+        ]
+    }
+    manifest_path = tmp_path / "manifest.yaml"
+    manifest_path.write_text(yaml.dump(manifest), encoding="utf-8")
+
+    violations = validate_manifest(manifest_path, workflows_dir)
+    assert len(violations) == 1
+    assert violations[0].artifact == "junit-game.xml"
+
+
+def test_real_manifest_covers_extended_workflows(repo_root: Path) -> None:
+    """issue #61：manifest 须声明 ci-main / ci-nightly / ci-game，且真实 YAML 全部通过。"""
+    manifest_path = repo_root / ".github" / "workflow-artifact-manifest.yaml"
+    workflows_dir = repo_root / ".github" / "workflows"
+    if not manifest_path.is_file():
+        pytest.skip("manifest 尚未合入当前分支")
+
+    manifest = yaml.safe_load(manifest_path.read_text(encoding="utf-8"))
+    declared = {entry["file"] for entry in manifest["workflows"]}
+    assert {"ci-pr.yml", "ci-main.yml", "ci-nightly.yml", "ci-game.yml"} <= declared
+
+    violations = validate_manifest(manifest_path, workflows_dir)
+    assert violations == []
+
+
 def test_main_exit_code_on_violation(tmp_path: Path) -> None:
     workflows_dir = _write_workflow(
         tmp_path,

--- a/tests/unit/test_policy_files.py
+++ b/tests/unit/test_policy_files.py
@@ -12,6 +12,8 @@ POLICY_PATHS = [
     ".github/scripts/check_ruff_baseline.py",
     ".github/scripts/check_mypy_baseline.py",
     ".github/scripts/check_pytest_baseline.py",
+    ".github/scripts/check_workflow_artifact_order.py",
+    ".github/workflow-artifact-manifest.yaml",
     ".github/pytest-baseline.json",
     ".github/requirements-lint.txt",
     ".github/mypy-policy.ini",
@@ -23,6 +25,8 @@ POLICY_PATHS = [
 CODEOWNER_PATTERNS = [
     ".github/workflows/",
     ".github/scripts/check_*_baseline.py",
+    ".github/scripts/check_workflow_artifact_order.py",
+    ".github/workflow-artifact-manifest.yaml",
     ".github/pytest-baseline.json",
     ".github/requirements-lint.txt",
     ".github/mypy-policy.ini",


### PR DESCRIPTION
## Summary

- 扩展 `.github/workflow-artifact-manifest.yaml` 覆盖 `ci-main` / `ci-nightly` / `ci-game` 的 JUnit / evidence upload
- `scripts/verify.sh` 增加硬门槛步骤（与 CI 同脚本）
- 治理文档 + CODEOWNERS + `test_policy_files` 纳入校验脚本与 manifest（政策文件变更）

Fixes #61

## 验收结论

人工验收通过（dev-workflow-2.0 run `.agent-runs/issue-61/`）：
- 单测 13/13 ✅
- 真实 YAML 校验 exit 0 ✅
- 故意破坏 manifest → exit 1 ✅

## Test plan

- [x] `pytest tests/unit/test_ci_workflow_artifact_order.py tests/unit/test_policy_files.py -q`
- [x] `python .github/scripts/check_workflow_artifact_order.py`
- [ ] PR Check Summary CI 绿

## 政策变更说明

变更原因：#51 遗留覆盖面补强；把 artifact 顺序门禁纳入本地 verify 与政策保护清单。  
影响：改 CODEOWNERS / governance / manifest；日常功能 PR 不受影响。  
验证：上述单测 + 脚本正反例。

Made with [Cursor](https://cursor.com)