### PR TITLE
fix(adapters): choose_map_node 非 MAP 祝福分支收敛与状态机放行（issue #57）

### DIFF
--- a/src/sts2_autotest/adapters/cli_mod.py
+++ b/src/sts2_autotest/adapters/cli_mod.py
@@ -536,9 +536,11 @@ class CliModAdapter:
                 cur = self._cached_state
             if cur.screen == GameScreen.COMBAT:
                 return ActionResult(status="success", state_changed=False)
-            if cur.screen in {GameScreen.CARD_REWARD, GameScreen.TRI_SELECT}:
-                # Neow 祝福带出奖励/三选一屏时，先推进到 MAP 再选节点（真机曾卡在
-                # CARD_REWARD：choose_map_node 短路为空操作 → 后续 give_card 无法执行）。
+            if cur.screen in {GameScreen.CARD_REWARD, GameScreen.TRI_SELECT, GameScreen.BUNDLE_SELECTION}:
+                # Neow 祝福带出奖励/三选一/包裹选择屏时，先推进到 MAP 再选节点
+                # （真机曾卡在 CARD_REWARD：choose_map_node 短路为空操作 → 后续
+                # give_card 无法执行；BUNDLE_SELECTION 下发选节点报 Game not
+                # actionable，issue #57）。
                 converge = self._advance_dialogue_to_map_sync()
                 if converge.status != "success":
                     return converge
@@ -1068,8 +1070,10 @@ def _screen_to_actions(screen: GameScreen) -> list[str]:
         GameScreen.REST: ["choose_rest_option", "probe"],
         GameScreen.EVENT: ["start_new_run", "select_character", "embark", "choose_event", "advance_dialogue", "choose_map_node", "probe"],
         GameScreen.CHEST: ["open_chest", "pick_relic", "probe"],
-        GameScreen.BUNDLE_SELECTION: ["bundle_select", "bundle_confirm", "bundle_cancel", "advance_dialogue", "probe"],
-        GameScreen.TRI_SELECT: ["tri_select_card", "tri_select_skip", "advance_dialogue", "probe"],
+        # 非 MAP 祝福分支（issue #57）：choose_map_node 是复合推进动作——先收敛
+        # 包裹/三选一/奖励屏再选节点（见 _act_sync 的 choose_map_node 分支）。
+        GameScreen.BUNDLE_SELECTION: ["bundle_select", "bundle_confirm", "bundle_cancel", "advance_dialogue", "choose_map_node", "probe"],
+        GameScreen.TRI_SELECT: ["tri_select_card", "tri_select_skip", "advance_dialogue", "choose_map_node", "probe"],
         GameScreen.BOSS_REWARD: ["reward_claim", "relic_select", "relic_skip", "probe"],
         GameScreen.CARD_REWARD: ["start_new_run", "select_character", "embark", "choose_map_node", "enter_combat", "choose_event", "advance_dialogue", "combat_basic_policy", "reward_choose_card", "reward_skip_card", "skip_card_reward", "reward_claim", "probe"],
         GameScreen.RELIC_REWARD: ["reward_claim", "relic_select", "relic_skip", "probe"],

--- a/src/sts2_autotest/common/state.py
+++ b/src/sts2_autotest/common/state.py
@@ -69,13 +69,16 @@ _ALLOWED_TRANSITIONS: dict[GameScreen, frozenset[GameScreen]] = {
         GameScreen.BUNDLE_SELECTION, GameScreen.TRI_SELECT,
     }),
     GameScreen.CHEST: frozenset({GameScreen.MAP}),
+    # Neow 非 MAP 祝福分支（卷轴箱/铅制镇纸/失物盒）是 EVENT 的延展屏：
+    # 复合动作收敛时游戏可能直接进入第一场战斗（issue #57），故与 EVENT 一致
+    # 放行 COMBAT。
     GameScreen.BUNDLE_SELECTION: frozenset({
-        GameScreen.EVENT, GameScreen.MAP,
+        GameScreen.EVENT, GameScreen.MAP, GameScreen.COMBAT,
     }),
     GameScreen.TRI_SELECT: frozenset({
-        GameScreen.EVENT, GameScreen.MAP,
+        GameScreen.EVENT, GameScreen.MAP, GameScreen.COMBAT,
     }),
-    GameScreen.CARD_REWARD: frozenset({GameScreen.MAP}),
+    GameScreen.CARD_REWARD: frozenset({GameScreen.MAP, GameScreen.COMBAT}),
     GameScreen.RELIC_REWARD: frozenset({GameScreen.MAP}),
     GameScreen.BOSS_REWARD: frozenset({GameScreen.MAP, GameScreen.VICTORY}),
     GameScreen.GAME_OVER: frozenset(),

--- a/tests/unit/test_cli_mod_adapter.py
+++ b/tests/unit/test_cli_mod_adapter.py
@@ -205,6 +205,31 @@ class TestGetAvailableActions:
         assert "grid_select_card" in result
         assert "advance_dialogue" in result
 
+    @patch("sts2_autotest.adapters.cli_mod.subprocess.Popen")
+    @pytest.mark.parametrize(
+        "state_payload",
+        [
+            # 卷轴箱：CLI 可能直接以 BUNDLE_SELECTION 上报，或 UNKNOWN + bundle_select
+            # 载荷（数据驱动重映射兜底路径）。
+            {"screen": "BUNDLE_SELECTION"},
+            {"screen": "UNMAPPED_BUNDLE", "bundle_select": {"bundles": [{"index": 0}]}},
+            {"screen": "TRI_SELECT"},
+            {"screen": "CARD_REWARD"},
+        ],
+    )
+    def test_neow_blessing_branches_offer_choose_map_node(
+        self,
+        mock_popen: MagicMock,
+        adapter: CliModAdapter,
+        state_payload: dict[str, Any],
+    ) -> None:
+        """非 MAP 祝福分支（BUNDLE_SELECTION/TRI_SELECT/CARD_REWARD）必须产出
+        choose_map_node 可推进动作（issue #57 缺口 2），否则复合动作序列卡在
+        ``Game not actionable`` 等待直至超时。"""
+        mock_popen.return_value = _mock_popen_ok(state_payload)
+        result = _run(adapter.get_available_actions())
+        assert "choose_map_node" in result
+
 
 class TestAct:
     """act() tests."""
@@ -824,6 +849,48 @@ class TestAct:
         commands = [call.args[0] for call in mock_popen.call_args_list]
         assert commands == [
             ["sts2", "tri_select_skip"],
+            ["sts2", "state"],
+            ["sts2", "choose_map_node", "3", "0"],
+        ]
+
+    @patch("sts2_autotest.adapters.cli_mod.subprocess.Popen")
+    def test_choose_map_node_converges_bundle_selection_to_map(
+        self, mock_popen: MagicMock, adapter: CliModAdapter
+    ) -> None:
+        """卷轴箱祝福带出 BUNDLE_SELECTION 时，choose_map_node 必须先
+        bundle_select+confirm 收敛推进到 MAP 再选节点，不能把选节点命令直接
+        下发到非 MAP 屏（真机报 ``Game not actionable``，issue #57）。"""
+        adapter._cached_state = GameState(screen=GameScreen.BUNDLE_SELECTION)
+        adapter._cache_stale = False
+        mock_popen.side_effect = [
+            _mock_popen_ok({}),  # bundle_select 0
+            _mock_popen_ok({}),  # bundle_confirm
+            _mock_popen_ok(  # state → MAP
+                {
+                    "screen": "MAP",
+                    "map": {
+                        "travelable_coords": [{"col": 3, "row": 0}],
+                        "nodes": [
+                            {
+                                "col": 3,
+                                "row": 0,
+                                "type": "MONSTER",
+                                "state": "TRAVELABLE",
+                            }
+                        ],
+                    },
+                }
+            ),
+            _mock_popen_ok({}),  # choose_map_node 3 0
+        ]
+
+        result = _run(adapter.act("choose_map_node", {"col": 2, "row": 1}))
+
+        assert result.status == "success"
+        commands = [call.args[0] for call in mock_popen.call_args_list]
+        assert commands == [
+            ["sts2", "bundle_select", "0"],
+            ["sts2", "bundle_confirm"],
             ["sts2", "state"],
             ["sts2", "choose_map_node", "3", "0"],
         ]

--- a/tests/unit/test_common_state.py
+++ b/tests/unit/test_common_state.py
@@ -111,11 +111,30 @@ class TestAllowedTransitions:
 
     def test_reward_states_return_to_map(self) -> None:
         for state in (
-            GameScreen.CARD_REWARD,
             GameScreen.RELIC_REWARD,
             GameScreen.CHEST,
         ):
             assert state.allowed_transitions == frozenset({GameScreen.MAP})
+
+    def test_card_reward_returns_to_map_or_combat(self) -> None:
+        """失物盒等 Neow 奖励收敛后回 MAP，也可能直接进第一场战斗（issue #57）。"""
+        transitions = GameScreen.CARD_REWARD.allowed_transitions
+        assert transitions == frozenset({GameScreen.MAP, GameScreen.COMBAT})
+
+    def test_neow_blessing_branches_can_converge_to_combat(self) -> None:
+        """Neow 非 MAP 祝福分支收敛后可直接进第一场战斗（issue #57）。
+
+        卷轴箱（BUNDLE_SELECTION）/铅制镇纸（TRI_SELECT）/失物盒（CARD_REWARD）
+        的复合推进收敛时游戏可能已进入 COMBAT，转移表必须放行，否则复合动作
+        序列被 state_engine 以 ``Illegal state transition: CARD_REWARD → COMBAT``
+        拒绝（真机 case-r8t 证据）。
+        """
+        for source in (
+            GameScreen.BUNDLE_SELECTION,
+            GameScreen.TRI_SELECT,
+            GameScreen.CARD_REWARD,
+        ):
+            assert GameScreen.COMBAT in source.allowed_transitions
 
     def test_boss_reward_can_go_to_map_or_victory(self) -> None:
         transitions = GameScreen.BOSS_REWARD.allowed_transitions

--- a/tests/unit/test_state_engine.py
+++ b/tests/unit/test_state_engine.py
@@ -29,6 +29,29 @@ class TestTransitionValidation:
     ) -> None:
         assert engine.validate_transition(GameScreen.EVENT, GameScreen.COMBAT) is True
 
+    def test_neow_blessing_branches_can_converge_into_combat(
+        self, engine: StateEngine
+    ) -> None:
+        """Neow 非 MAP 祝福分支的复合动作收敛可直接进战斗（issue #57）。
+
+        真机 case-r8t 曾报 ``Illegal state transition: CARD_REWARD → COMBAT``：
+        失物盒奖励跳过时游戏已进入第一场战斗，state_engine 不得拒绝。
+        """
+        assert engine.validate_transition(GameScreen.CARD_REWARD, GameScreen.COMBAT) is True
+        assert engine.validate_transition(GameScreen.BUNDLE_SELECTION, GameScreen.COMBAT) is True
+        assert engine.validate_transition(GameScreen.TRI_SELECT, GameScreen.COMBAT) is True
+
+    def test_neow_blessing_branches_update_state_without_error(
+        self, engine: StateEngine
+    ) -> None:
+        """复合动作序列经 update_state 推进 CARD_REWARD → COMBAT 不抛异常。"""
+        result = engine.update_state(
+            GameScreen.CARD_REWARD,
+            GameState(screen=GameScreen.COMBAT),
+            event="choose_map_node",
+        )
+        assert result == GameScreen.COMBAT
+
     def test_illegal_transition(self, engine: StateEngine) -> None:
         assert engine.validate_transition(
             GameScreen.MAIN_MENU, GameScreen.COMBAT


### PR DESCRIPTION
## 概述

修复 #57：v0.107.1+ 多阶段 Neow 祝福流程中 `choose_map_node` 在非 MAP 分支（BUNDLE_SELECTION / TRI_SELECT / CARD_REWARD）的三层兼容缺口。Draft PR——真机 TC-PREPARE-NEW-RUN 连续 ≥10 轮验收由测试环节执行后转正式。

Closes #57

## 三层修复

| 缺口（issue 证据） | 修复 |
|---|---|
| BUNDLE_SELECTION 收敛：卷轴箱祝福进入后无可用动作，`choose_map_node` 直接下发报 `Game not actionable` | `_act_sync` 的 choose_map_node 复合推进纳入 BUNDLE_SELECTION——先 `bundle_select`+`bundle_confirm` 收敛再选节点 |
| 可用动作表：BUNDLE_SELECTION/TRI_SELECT 下 `get_available_actions` 未产出可推进动作，navigator 卡 actionable 等待直至超时 | `_screen_to_actions` 两屏动作表补 `choose_map_node`（复合动作语义，与 CARD_REWARD 行既有做法一致） |
| 复合动作状态机：`Illegal state transition: CARD_REWARD → COMBAT`（case-r8t） | `_ALLOWED_TRANSITIONS` 放行 BUNDLE_SELECTION/TRI_SELECT/CARD_REWARD → COMBAT（祝福收敛可直接进第一场战斗，与 EVENT 后继对齐） |

## 验证

- [x] TDD：7 个逐路径断言先失败（red）后通过（green）
- [x] 全量单测 `pytest tests/unit/ -q` → **1953 passed**, 2 warnings
- [x] `lint-imports` → Contracts: 1 kept, 0 broken
- [x] mypy 增量基线（`check_mypy_baseline.py` vs `origin/main`）→ **0 new debt**
- [x] ruff 增量基线（`check_ruff_baseline.py` vs `origin/main`）→ **0 new findings**
- [ ] 真机 v0.107.1+：TC-PREPARE-NEW-RUN 连续 ≥10 轮无卡屏（测试环节执行）

> 注：本地 `./scripts/verify.sh` 在云 VM（Linux）执行时，macOS runner 相关 shell 测试失败；单元测试、lint-imports 及 mypy/ruff 增量基线检查已绿。真机验收由测试环节补齐。

## API 来源

未新增 BaseLib/STS2 API 调用；全部复用本仓库既有可工作实现（`_bundle_select_and_confirm_sync`、`_advance_dialogue_to_map_sync` 的 BUNDLE 收敛循环、CARD_REWARD/TRI_SELECT 既有收敛分支）。

## 审核提示

- 分支已 rebase 到 `origin/main`，PR 仅包含 issue #57 相关改动。
- 转移表放宽仅限三个祝福分支屏；RELIC_REWARD/BOSS_REWARD 等无关行未动。
- 工作区已清理，无遗留脏改动计入本 PR。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
